### PR TITLE
Fix Jira Server 10.0.0 auth: OR semantics across operations

### DIFF
--- a/Atlassian/Jira/OpenAPIs/jira_server_10.0.0.json
+++ b/Atlassian/Jira/OpenAPIs/jira_server_10.0.0.json
@@ -471,10 +471,18 @@
         "properties": {
           "allowedValues": {
             "type": "array",
-            "example": ["red", "blue", "default value"],
+            "example": [
+              "red",
+              "blue",
+              "default value"
+            ],
             "items": {
               "type": "object",
-              "example": ["red", "blue", "default value"]
+              "example": [
+                "red",
+                "blue",
+                "default value"
+              ]
             }
           },
           "autoCompleteUrl": {
@@ -499,7 +507,10 @@
           },
           "operations": {
             "type": "array",
-            "example": ["set", "add"],
+            "example": [
+              "set",
+              "add"
+            ],
             "items": {
               "type": "string",
               "example": "[\"set\",\"add\"]"
@@ -1119,7 +1130,11 @@
         "properties": {
           "issues": {
             "type": "array",
-            "example": ["PR-1", "10001", "PR-3"],
+            "example": [
+              "PR-1",
+              "10001",
+              "PR-3"
+            ],
             "items": {
               "type": "string",
               "example": "[\"PR-1\",\"10001\",\"PR-3\"]"
@@ -1666,7 +1681,11 @@
         "properties": {
           "sprintIds": {
             "type": "array",
-            "example": [10001, 10004, 10005],
+            "example": [
+              10001,
+              10004,
+              10005
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -2196,7 +2215,10 @@
           "assigneeType": {
             "type": "string",
             "example": "PROJECT_LEAD",
-            "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+            "enum": [
+              "PROJECT_LEAD",
+              "UNASSIGNED"
+            ]
           },
           "avatarId": {
             "type": "integer",
@@ -2705,7 +2727,12 @@
           "type": {
             "type": "string",
             "example": "ANONYMIZE",
-            "enum": ["ANONYMIZE", "TRANSFER_OWNERSHIP", "REMOVE", "MANUAL"]
+            "enum": [
+              "ANONYMIZE",
+              "TRANSFER_OWNERSHIP",
+              "REMOVE",
+              "MANUAL"
+            ]
           },
           "uri": {
             "type": "string",
@@ -2765,7 +2792,9 @@
           "defaultGroups": {
             "uniqueItems": true,
             "type": "array",
-            "example": ["jira-software-users"],
+            "example": [
+              "jira-software-users"
+            ],
             "items": {
               "type": "string",
               "example": "[\"jira-software-users\"]"
@@ -2778,7 +2807,10 @@
           "groups": {
             "uniqueItems": true,
             "type": "array",
-            "example": ["jira-software-users", "jira-testers"],
+            "example": [
+              "jira-software-users",
+              "jira-testers"
+            ],
             "items": {
               "type": "string",
               "example": "[\"jira-software-users\",\"jira-testers\"]"
@@ -2831,7 +2863,12 @@
         "properties": {
           "idsOrKeys": {
             "type": "array",
-            "example": ["100034", "13543", "FOOPROJ", "BAZZPROJ"],
+            "example": [
+              "100034",
+              "13543",
+              "FOOPROJ",
+              "BAZZPROJ"
+            ],
             "items": {
               "type": "string",
               "example": "[\"100034\",\"13543\",\"FOOPROJ\",\"BAZZPROJ\"]"
@@ -3016,7 +3053,13 @@
         "properties": {
           "jqlReservedWords": {
             "type": "array",
-            "example": ["empty", "and", "or", "in", "distinct"],
+            "example": [
+              "empty",
+              "and",
+              "or",
+              "in",
+              "distinct"
+            ],
             "items": {
               "type": "string",
               "example": "[\"empty\",\"and\",\"or\",\"in\",\"distinct\"]"
@@ -3043,7 +3086,9 @@
                   ">",
                   ">="
                 ],
-                "types": ["com.atlassian.crowd.embedded.api.User"]
+                "types": [
+                  "com.atlassian.crowd.embedded.api.User"
+                ]
               },
               {
                 "value": "assignee",
@@ -3064,7 +3109,9 @@
                   "changed",
                   "is not"
                 ],
-                "types": ["com.atlassian.crowd.embedded.api.User"]
+                "types": [
+                  "com.atlassian.crowd.embedded.api.User"
+                ]
               }
             ],
             "items": {
@@ -3078,12 +3125,16 @@
               {
                 "value": "currentLogin()",
                 "displayName": "currentLogin()",
-                "types": ["java.util.Date"]
+                "types": [
+                  "java.util.Date"
+                ]
               },
               {
                 "value": "currentUser()",
                 "displayName": "currentUser()",
-                "types": ["com.atlassian.crowd.embedded.api.User"]
+                "types": [
+                  "com.atlassian.crowd.embedded.api.User"
+                ]
               }
             ],
             "items": {
@@ -3128,7 +3179,9 @@
           "ignoredProjectIds": {
             "uniqueItems": true,
             "type": "array",
-            "example": ["10000"],
+            "example": [
+              "10000"
+            ],
             "items": {
               "type": "string",
               "example": "[\"10000\"]"
@@ -3192,7 +3245,9 @@
         "properties": {
           "deletedCustomFields": {
             "type": "array",
-            "example": ["customfield_10000"],
+            "example": [
+              "customfield_10000"
+            ],
             "items": {
               "type": "string",
               "example": "[\"customfield_10000\"]"
@@ -3299,7 +3354,13 @@
           "columnConfig": {
             "type": "string",
             "example": null,
-            "enum": ["SYSTEM", "EXPLICIT", "FILTER", "USER", "NONE"]
+            "enum": [
+              "SYSTEM",
+              "EXPLICIT",
+              "FILTER",
+              "USER",
+              "NONE"
+            ]
           },
           "columnLayoutItems": {
             "type": "array",
@@ -3633,7 +3694,10 @@
           },
           "issueTypeIds": {
             "type": "array",
-            "example": ["1", "2"],
+            "example": [
+              "1",
+              "2"
+            ],
             "items": {
               "type": "string",
               "example": "[\"1\",\"2\"]"
@@ -3660,7 +3724,10 @@
           },
           "projectIds": {
             "type": "array",
-            "example": [10000, 10001],
+            "example": [
+              10000,
+              10001
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -3709,7 +3776,10 @@
           },
           "issueTypeIds": {
             "type": "array",
-            "example": ["1", "2"],
+            "example": [
+              "1",
+              "2"
+            ],
             "items": {
               "type": "string",
               "example": "[\"1\",\"2\"]"
@@ -3721,7 +3791,10 @@
           },
           "projectIds": {
             "type": "array",
-            "example": [10000, 10001],
+            "example": [
+              10000,
+              10001
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -3749,7 +3822,10 @@
         "properties": {
           "childrenIds": {
             "type": "array",
-            "example": [4, 5],
+            "example": [
+              4,
+              5
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -3925,7 +4001,11 @@
           "scope": {
             "type": "string",
             "example": "AUTHENTICATED",
-            "enum": ["GLOBAL", "AUTHENTICATED", "PRIVATE"]
+            "enum": [
+              "GLOBAL",
+              "AUTHENTICATED",
+              "PRIVATE"
+            ]
           }
         },
         "example": null,
@@ -3957,7 +4037,9 @@
         "example": null
       },
       "EditorMarkupParameters": {
-        "required": ["fieldId"],
+        "required": [
+          "fieldId"
+        ],
         "type": "object",
         "properties": {
           "fieldId": {
@@ -4074,7 +4156,10 @@
           },
           "fieldConfigIds": {
             "type": "array",
-            "example": [10050, 10051],
+            "example": [
+              10050,
+              10051
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -4350,7 +4435,11 @@
           "type": {
             "type": "string",
             "example": "SINGLE",
-            "enum": ["ADMIN", "SINGLE", "MULTIPLE"]
+            "enum": [
+              "ADMIN",
+              "SINGLE",
+              "MULTIPLE"
+            ]
           }
         },
         "example": null,
@@ -4791,7 +4880,10 @@
           "type": {
             "type": "string",
             "example": null,
-            "enum": ["subtask", "standard"]
+            "enum": [
+              "subtask",
+              "standard"
+            ]
           }
         },
         "example": null
@@ -4910,7 +5002,11 @@
           },
           "issueTypeIds": {
             "type": "array",
-            "example": ["1", "4", "3"],
+            "example": [
+              "1",
+              "4",
+              "3"
+            ],
             "items": {
               "type": "string",
               "example": "[\"1\",\"4\",\"3\"]"
@@ -5161,7 +5257,12 @@
           "position": {
             "type": "string",
             "example": null,
-            "enum": ["Earlier", "Later", "First", "Last"]
+            "enum": [
+              "Earlier",
+              "Later",
+              "First",
+              "Last"
+            ]
           }
         },
         "example": null
@@ -5625,7 +5726,10 @@
           "type": {
             "type": "string",
             "example": null,
-            "enum": ["GLOBAL", "PROJECT"]
+            "enum": [
+              "GLOBAL",
+              "PROJECT"
+            ]
           }
         },
         "description": "A map of permission keys to permission objects.",
@@ -5889,7 +5993,13 @@
           },
           "optionIds": {
             "type": "array",
-            "example": ["1", "2", "3", "4", "5"],
+            "example": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
             "items": {
               "type": "string",
               "example": "[\"1\",\"2\",\"3\",\"4\",\"5\"]"
@@ -6067,8 +6177,12 @@
             "additionalProperties": {
               "type": "array",
               "example": {
-                "atlassian-user-role-actor": ["admin"],
-                "atlassian-group-role-actor": ["jira-developers"]
+                "atlassian-user-role-actor": [
+                  "admin"
+                ],
+                "atlassian-group-role-actor": [
+                  "jira-developers"
+                ]
               },
               "items": {
                 "type": "string",
@@ -6076,8 +6190,12 @@
               }
             },
             "example": {
-              "atlassian-user-role-actor": ["admin"],
-              "atlassian-group-role-actor": ["jira-developers"]
+              "atlassian-user-role-actor": [
+                "admin"
+              ],
+              "atlassian-group-role-actor": [
+                "jira-developers"
+              ]
             }
           },
           "id": {
@@ -6157,7 +6275,10 @@
           "assigneeType": {
             "type": "string",
             "example": "PROJECT_LEAD",
-            "enum": ["PROJECT_LEAD", "UNASSIGNED"]
+            "enum": [
+              "PROJECT_LEAD",
+              "UNASSIGNED"
+            ]
           },
           "avatarId": {
             "type": "integer",
@@ -6325,12 +6446,21 @@
           "status": {
             "type": "string",
             "example": "PENDING",
-            "enum": ["PENDING", "ACTIVE", "RUNNING", "FAILED", "COMPLETE"]
+            "enum": [
+              "PENDING",
+              "ACTIVE",
+              "RUNNING",
+              "FAILED",
+              "COMPLETE"
+            ]
           },
           "type": {
             "type": "string",
             "example": "IMMEDIATE",
-            "enum": ["IMMEDIATE", "DELAYED"]
+            "enum": [
+              "IMMEDIATE",
+              "DELAYED"
+            ]
           }
         },
         "example": null
@@ -6547,7 +6677,11 @@
           },
           "fields": {
             "type": "array",
-            "example": ["summary", "status", "assignee"],
+            "example": [
+              "summary",
+              "status",
+              "assignee"
+            ],
             "items": {
               "type": "string",
               "example": "[\"summary\",\"status\",\"assignee\"]"
@@ -6739,7 +6873,11 @@
             }
           }
         },
-        "example": ["jira-core", "jira-admin", "important"],
+        "example": [
+          "jira-core",
+          "jira-admin",
+          "important"
+        ],
         "xml": {
           "name": "list"
         }
@@ -6839,12 +6977,21 @@
           "defaultUnit": {
             "type": "string",
             "example": "day",
-            "enum": ["minute", "hour", "day", "week"]
+            "enum": [
+              "minute",
+              "hour",
+              "day",
+              "week"
+            ]
           },
           "timeFormat": {
             "type": "string",
             "example": "pretty",
-            "enum": ["pretty", "days", "hours"]
+            "enum": [
+              "pretty",
+              "days",
+              "hours"
+            ]
           },
           "workingDaysPerWeek": {
             "type": "number",
@@ -7249,7 +7396,9 @@
           },
           "applicationKeys": {
             "type": "array",
-            "example": ["jira-core"],
+            "example": [
+              "jira-core"
+            ],
             "items": {
               "type": "string",
               "example": "[\"jira-core\"]"
@@ -7367,7 +7516,12 @@
           "position": {
             "type": "string",
             "example": "Earlier",
-            "enum": ["Earlier", "Later", "First", "Last"]
+            "enum": [
+              "Earlier",
+              "Later",
+              "First",
+              "Last"
+            ]
           }
         },
         "example": null,
@@ -7420,7 +7574,10 @@
           "type": {
             "type": "string",
             "example": "group",
-            "enum": ["group", "role"]
+            "enum": [
+              "group",
+              "role"
+            ]
           },
           "value": {
             "type": "string",
@@ -7618,7 +7775,12 @@
             "uniqueItems": true,
             "type": "array",
             "description": "List of worklog ids",
-            "example": [1, 2, 5, 10],
+            "example": [
+              1,
+              2,
+              5,
+              10
+            ],
             "items": {
               "type": "integer",
               "description": "List of worklog ids",
@@ -7735,7 +7897,7 @@
         "example": null
       }
     }
-  },  
+  },
   "security": [
     {
       "basic": []
@@ -8018,7 +8180,9 @@
   "paths": {
     "/agile/1.0/backlog/issue": {
       "post": {
-        "tags": ["backlog"],
+        "tags": [
+          "backlog"
+        ],
         "description": "Move issues to the backlog. This operation is equivalent to remove future and active sprints from a given set of issues. At most 50 issues may be moved at once.",
         "operationId": "moveIssuesToBacklog",
         "requestBody": {
@@ -8061,7 +8225,9 @@
     },
     "/agile/1.0/board": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all boards. This only includes boards that the user has permission to view.",
         "operationId": "getAllBoards",
         "parameters": [
@@ -8130,13 +8296,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Creates a new board. Board name, type and filter Id is required.\n- name - Must be less than 255 characters.\n- type - Valid values: scrum, kanban\n- filterId - Id of a filter that the user has permissions to view. Note, if the user does not have the 'Create shared objects' permission and tries to create a shared board, a private board will be created instead (remember that board sharing depends on the filter sharing).\nNote:\n- If you want to create a new project with an associated board, use the JIRA platform REST API. For more information, see the Create project method. The projectTypeKey for software boards must be 'software' and the projectTemplateKey must be either com.pyxis.greenhopper.jira:gh-kanban-template or com.pyxis.greenhopper.jira:gh-scrum-template.\n- You can create a filter using the JIRA REST API. For more information, see the Create filter method.\n- If you do not ORDER BY the Rank field for the filter of your board, you will not be able to reorder issues on the board.",
         "operationId": "createBoard",
         "requestBody": {
@@ -8173,7 +8343,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8181,7 +8353,9 @@
     },
     "/agile/1.0/board/{boardId}": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns a single board, for a given board Id.",
         "operationId": "getBoard",
         "parameters": [
@@ -8222,13 +8396,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Deletes the board.",
         "operationId": "deleteBoard",
         "parameters": [
@@ -8256,7 +8434,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8264,7 +8444,9 @@
     },
     "/agile/1.0/board/{boardId}/backlog": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all issues from a board's backlog, for a given board Id.",
         "operationId": "getIssuesForBacklog",
         "parameters": [
@@ -8358,7 +8540,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8366,7 +8550,9 @@
     },
     "/agile/1.0/board/{boardId}/configuration": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Get the board configuration.\nThe response contains the following fields:\n- id - Id of the board.\n- name - Name of the board.\n- filter - Reference to the filter used by the given board.\n- subQuery (Kanban only) - JQL subquery used by the given board.\n- columnConfig - The column configuration lists the columns for the board, in the order defined in the column configuration.\nFor each column, it shows the issue status mapping\nas well as the constraint type (Valid values: none, issueCount, issueCountExclSubs) for the min/max number of issues.\nNote, the last column with statuses mapped to it is treated as the \"Done\" column,\nwhich means that issues in that column will be marked as already completed.\n- estimation (Scrum only) - Contains information about type of estimation used for the board. Valid values: none, issueCount, field.\nIf the estimation type is \"field\", the Id and display name of the field used for estimation is also returned.\nNote, estimates for an issue can be updated by a PUT /rest/api/2/issue/{issueIdOrKey} request, however the fields must be on the screen.\n\"timeoriginalestimate\" field will never be on the screen, so in order to update it \"originalEstimate\" in \"timetracking\" field should be updated.\n- ranking - Contains information about custom field used for ranking in the given board.",
         "operationId": "getConfiguration",
         "parameters": [
@@ -8404,7 +8590,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8412,7 +8600,9 @@
     },
     "/agile/1.0/board/{boardId}/epic": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all epics from the board, for the given board Id. This only includes epics that the user has permission to view. Note, if the user does not have permission to view the board, no epics will be returned at all.",
         "operationId": "getEpics",
         "parameters": [
@@ -8479,7 +8669,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8487,7 +8679,9 @@
     },
     "/agile/1.0/board/{boardId}/epic/none/issue": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all issues that do not belong to any epic on a board, for a given board Id.",
         "operationId": "getIssuesWithoutEpic",
         "parameters": [
@@ -8581,7 +8775,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8589,7 +8785,9 @@
     },
     "/agile/1.0/board/{boardId}/epic/{epicId}/issue": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all issues that belong to an epic on the board, for the given epic Id and the board Id.",
         "operationId": "getIssuesForEpic",
         "parameters": [
@@ -8693,7 +8891,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8701,7 +8901,9 @@
     },
     "/agile/1.0/board/{boardId}/issue": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all issues from a board, for a given board Id. This only includes issues that the user has permission to view. Note, if the user does not have permission to view the board, no issues will be returned at all. Issues returned from this resource include Agile fields, like sprint, closedSprints, flagged, and epic. By default, the returned issues are ordered by rank.",
         "operationId": "getIssuesForBoard",
         "parameters": [
@@ -8795,7 +8997,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8803,7 +9007,9 @@
     },
     "/agile/1.0/board/{boardId}/project": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all projects that are associated with the board, for the given board Id. A project is associated with a board only if the board filter explicitly filters issues by the project and guaranties that all issues will come for one of those projects e.g. board's filter with \"project in (PR-1, PR-1) OR reporter = admin\" jql Projects are returned only if user can browse all projects that are associated with the board. Note, if the user does not have permission to view the board, no projects will be returned at all. Returned projects are ordered by the name.",
         "operationId": "getProjects",
         "parameters": [
@@ -8862,7 +9068,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8870,7 +9078,9 @@
     },
     "/agile/1.0/board/{boardId}/properties": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns the keys of all properties for the board identified by the id. The user who retrieves the property keys is required to have permissions to view the board.",
         "operationId": "getPropertiesKeys",
         "parameters": [
@@ -8907,7 +9117,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -8915,7 +9127,9 @@
     },
     "/agile/1.0/board/{boardId}/properties/{propertyKey}": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns the value of the property with a given key from the board identified by the provided id. The user who retrieves the property is required to have permissions to view the board.",
         "operationId": "getProperty",
         "parameters": [
@@ -8961,13 +9175,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Sets the value of the specified board's property. You can use this resource to store a custom data against the board identified by the id. The user who stores the data is required to have permissions to modify the board.",
         "operationId": "setProperty",
         "parameters": [
@@ -9016,13 +9234,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Removes the property from the board identified by the id. Ths user removing the property is required to have permissions to modify the board.",
         "operationId": "deleteProperty",
         "parameters": [
@@ -9061,7 +9283,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9069,7 +9293,9 @@
     },
     "/agile/1.0/board/{boardId}/settings/refined-velocity": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns the value of the setting for refined velocity chart",
         "operationId": "getRefinedVelocity",
         "parameters": [
@@ -9107,13 +9333,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Sets the value of the specified board's refined velocity setting.",
         "operationId": "setRefinedVelocity",
         "parameters": [
@@ -9163,7 +9393,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9171,7 +9403,9 @@
     },
     "/agile/1.0/board/{boardId}/sprint": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all sprints from a board, for a given board Id. This only includes sprints that the user has permission to view.",
         "operationId": "getAllSprints",
         "parameters": [
@@ -9237,7 +9471,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9245,7 +9481,9 @@
     },
     "/agile/1.0/board/{boardId}/sprint/{sprintId}/issue": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Get all issues you have access to that belong to the sprint from the board. Issue returned from this resource contains additional fields like: sprint, closedSprints, flagged and epic. Issues are returned ordered by rank. JQL order has higher priority than default rank.",
         "operationId": "getIssuesForSprint",
         "parameters": [
@@ -9349,7 +9587,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9357,7 +9597,9 @@
     },
     "/agile/1.0/board/{boardId}/version": {
       "get": {
-        "tags": ["board"],
+        "tags": [
+          "board"
+        ],
         "description": "Returns all versions from a board, for a given board Id. This only includes versions that the user has permission to view. Note, if the user does not have permission to view the board, no versions will be returned at all. Returned versions are ordered by the name of the project from which they belong and then by sequence defined by user.",
         "operationId": "getAllVersions",
         "parameters": [
@@ -9424,7 +9666,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9432,7 +9676,9 @@
     },
     "/agile/1.0/epic/none/issue": {
       "get": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Returns all issues that do not belong to any epic. This only includes issues that the user has permission to view. Issues returned from this resource include Agile fields, like sprint, closedSprints, flagged, and epic. By default, the returned issues are ordered by rank.",
         "operationId": "getIssuesWithoutEpic_1",
         "parameters": [
@@ -9513,13 +9759,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Removes issues from epics. The user needs to have the edit issue permission for all issue they want to remove from epics. The maximum number of issues that can be moved in one operation is 50.",
         "operationId": "removeIssuesFromEpic",
         "requestBody": {
@@ -9552,7 +9802,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9560,7 +9812,9 @@
     },
     "/agile/1.0/epic/{epicIdOrKey}": {
       "get": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Returns the epic for a given epic Id. This epic will only be returned if the user has permission to view it.",
         "operationId": "getEpic",
         "parameters": [
@@ -9597,13 +9851,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Performs a partial update of the epic. A partial update means that fields not present in the request JSON will not be updated. Valid values for color are color_1 to color_9.",
         "operationId": "partiallyUpdateEpic",
         "parameters": [
@@ -9654,7 +9912,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9662,7 +9922,9 @@
     },
     "/agile/1.0/epic/{epicIdOrKey}/issue": {
       "get": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Returns all issues that belong to the epic, for the given epic Id. This only includes issues that the user has permission to view. Issues returned from this resource include Agile fields, like sprint, closedSprints, flagged, and epic. By default, the returned issues are ordered by rank.",
         "operationId": "getIssuesForEpic_1",
         "parameters": [
@@ -9755,13 +10017,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Moves issues to an epic, for a given epic id. Issues can be only in a single epic at the same time. That means that already assigned issues to an epic, will not be assigned to the previous epic anymore. The user needs to have the edit issue permission for all issue they want to move and to the epic. The maximum number of issues that can be moved in one operation is 50.",
         "operationId": "moveIssuesToEpic",
         "parameters": [
@@ -9805,7 +10071,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9813,7 +10081,9 @@
     },
     "/agile/1.0/epic/{epicIdOrKey}/rank": {
       "put": {
-        "tags": ["epic"],
+        "tags": [
+          "epic"
+        ],
         "description": "Moves (ranks) an epic before or after a given epic. If rankCustomFieldId is not defined, the default rank field will be used.",
         "operationId": "rankEpics",
         "parameters": [
@@ -9857,7 +10127,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9865,7 +10137,9 @@
     },
     "/agile/1.0/issue/rank": {
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Moves (ranks) issues before or after a given issue. At most 50 issues may be ranked at once. This operation may fail for some issues, although this will be rare. In that case the 207 status code is returned for the whole response and detailed information regarding each issue is available in the response body. If rankCustomFieldId is not defined, the default rank field will be used.",
         "operationId": "rankIssues",
         "requestBody": {
@@ -9905,7 +10179,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9913,7 +10189,9 @@
     },
     "/agile/1.0/issue/{issueIdOrKey}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns a single issue, for a given issue Id or issue key. Issues returned from this resource include Agile fields, like sprint, closedSprints, flagged, and epic.",
         "operationId": "getAgileIssue",
         "parameters": [
@@ -9980,7 +10258,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -9988,7 +10268,9 @@
     },
     "/agile/1.0/issue/{issueIdOrKey}/estimation": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the estimation of the issue and a fieldId of the field that is used for it.\nOriginal time internally stores and returns the estimation as a number of seconds.\nThe field used for estimation on the given board can be obtained from board configuration resource.\nMore information about the field are returned by edit meta resource or field resource.",
         "operationId": "getIssueEstimationForBoard",
         "parameters": [
@@ -10037,13 +10319,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Updates the estimation of the issue. boardId param is required. This param determines which field will be updated on a issue.\nNote that this resource changes the estimation field of the issue regardless of appearance the field on the screen.\nOriginal time tracking estimation field accepts estimation in formats like \"1w\", \"2d\", \"3h\", \"20m\" or number which represent number of minutes.\nHowever, internally the field stores and returns the estimation as a number of seconds.\nThe field used for estimation on the given board can be obtained from <a href=\"#agile/1.0/board-getConfiguration\">board configuration resource</a>.\nMore information about the field are returned by edit meta resource or field resource.",
         "operationId": "estimateIssueForBoard",
         "parameters": [
@@ -10103,7 +10389,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10111,7 +10399,9 @@
     },
     "/agile/1.0/sprint": {
       "post": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Creates a future sprint. Sprint name and origin board id are required. Start and end date are optional. Notes: The sprint name is trimmed. Only Jira administrators can create synced sprints.",
         "operationId": "createSprint",
         "requestBody": {
@@ -10151,7 +10441,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10159,7 +10451,9 @@
     },
     "/agile/1.0/sprint/unmap": {
       "put": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Sets the Synced flag to false for all sprints in the provided list.",
         "operationId": "unmapSprints",
         "requestBody": {
@@ -10192,7 +10486,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10200,7 +10496,9 @@
     },
     "/agile/1.0/sprint/unmap-all": {
       "put": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Sets the Synced flag to false for all sprints on this Jira instance. This operation is intended for cleanup only. It is highly destructive and not reversible. Use with caution.",
         "operationId": "unmapAllSprints",
         "responses": {
@@ -10219,7 +10517,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10227,7 +10527,9 @@
     },
     "/agile/1.0/sprint/{sprintId}": {
       "get": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Returns a single sprint, for a given sprint Id. The sprint will only be returned if the user can view the board that the sprint was created on, or view at least one of the issues in the sprint.",
         "operationId": "getSprint",
         "parameters": [
@@ -10268,13 +10570,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Performs a full update of a sprint.\nA full update means that the result will be exactly the same as the request body.\nAny fields not present in the request JSON will be set to null.\nNotes:\n- Sprints that are in a closed state cannot be updated.\n- A sprint can be started by updating the state to 'active'. This requires the sprint to be in the 'future' state and have a startDate and endDate set.\n- A sprint can be completed by updating the state to 'closed'. This action requires the sprint to be in the 'active' state. This sets the completeDate to the time of the request.\n- Other changes to state are not allowed.\n- The completeDate field cannot be updated manually.\n- Only Jira administrators can edit dates on sprints that are marked as synced.",
         "operationId": "updateSprint",
         "parameters": [
@@ -10326,13 +10632,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Performs a partial update of a sprint.\nA partial update means that fields not present in the request JSON will not be updated.\nNotes:\n- Sprints that are in a closed state cannot be updated.\n- A sprint can be started by updating the state to 'active'. This requires the sprint to be in the 'future' state and have a startDate and endDate set.\n- A sprint can be completed by updating the state to 'closed'. This action requires the sprint to be in the 'active' state. This sets the completeDate to the time of the request.\n- Other changes to state are not allowed.\n- The completeDate field cannot be updated manually.\n- Sprint goal can be removed by updating it's value to empty string\n- Only Jira administrators can edit dates on sprints that are marked as synced.",
         "operationId": "partiallyUpdateSprint",
         "parameters": [
@@ -10384,13 +10694,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Deletes a sprint. Once a sprint is deleted, all issues in the sprint will be moved to the backlog. To delete a synced sprint, you must unsync it first.",
         "operationId": "deleteSprint",
         "parameters": [
@@ -10424,7 +10738,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10432,7 +10748,9 @@
     },
     "/agile/1.0/sprint/{sprintId}/issue": {
       "get": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Returns all issues in a sprint, for a given sprint Id. This only includes issues that the user has permission to view. By default, the returned issues are ordered by rank.",
         "operationId": "getIssuesForSprint_1",
         "parameters": [
@@ -10523,13 +10841,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Moves issues to a sprint, for a given sprint Id. Issues can only be moved to open or active sprints. The maximum number of issues that can be moved in one operation is 50.",
         "operationId": "moveIssuesToSprint",
         "parameters": [
@@ -10574,7 +10896,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10582,7 +10906,9 @@
     },
     "/agile/1.0/sprint/{sprintId}/properties": {
       "get": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Returns the keys of all properties for the sprint identified by the id. The user who retrieves the property keys is required to have permissions to view the sprint.",
         "operationId": "getPropertiesKeys_1",
         "parameters": [
@@ -10622,7 +10948,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10630,7 +10958,9 @@
     },
     "/agile/1.0/sprint/{sprintId}/properties/{propertyKey}": {
       "get": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Returns the value of the property with a given key from the sprint identified by the provided id. The user who retrieves the property is required to have permissions to view the sprint.",
         "operationId": "getProperty_sprint",
         "parameters": [
@@ -10679,13 +11009,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Sets the value of the specified sprint's property. You can use this resource to store a custom data against the sprint identified by the id. The user who stores the data is required to have permissions to modify the sprint.",
         "operationId": "setProperty_1",
         "parameters": [
@@ -10730,13 +11064,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Removes the property from the sprint identified by the id. Ths user removing the property is required to have permissions to modify the sprint.",
         "operationId": "deleteProperty_sprint",
         "parameters": [
@@ -10778,7 +11116,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10786,7 +11126,9 @@
     },
     "/agile/1.0/sprint/{sprintId}/swap": {
       "post": {
-        "tags": ["sprint"],
+        "tags": [
+          "sprint"
+        ],
         "description": "Swap the position of the sprint with the second sprint.",
         "operationId": "swapSprint",
         "parameters": [
@@ -10828,7 +11170,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10836,7 +11180,9 @@
     },
     "/api/2/application-properties": {
       "get": {
-        "tags": ["application-properties"],
+        "tags": [
+          "application-properties"
+        ],
         "description": "Returns an application property.",
         "operationId": "getApplicationProperties",
         "parameters": [
@@ -10914,7 +11260,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10922,7 +11270,9 @@
     },
     "/api/2/application-properties/advanced-settings": {
       "get": {
-        "tags": ["application-properties"],
+        "tags": [
+          "application-properties"
+        ],
         "description": "Returns the properties that are displayed on the \"General Configuration > Advanced Settings\" page.",
         "operationId": "getAdvancedSettings",
         "responses": {
@@ -10969,7 +11319,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -10977,7 +11329,9 @@
     },
     "/api/2/application-properties/{id}": {
       "put": {
-        "tags": ["application-properties"],
+        "tags": [
+          "application-properties"
+        ],
         "description": "Modify an application property via PUT. The \"value\" field present in the PUT will override the existing value.",
         "operationId": "setPropertyViaRestfulTable",
         "parameters": [
@@ -11012,7 +11366,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11020,7 +11376,9 @@
     },
     "/api/2/applicationrole": {
       "get": {
-        "tags": ["applicationrole"],
+        "tags": [
+          "applicationrole"
+        ],
         "description": "Returns all ApplicationRoles in the system.",
         "operationId": "getAll",
         "responses": {
@@ -11043,13 +11401,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["applicationrole"],
+        "tags": [
+          "applicationrole"
+        ],
         "description": "Updates the ApplicationRoles with the passed data if the version hash is the same as the server. Only the groups and default groups setting of the role may be updated. Requests to change the key or the name of the role will be silently ignored. It is acceptable to pass only the roles that are updated as roles that are present in the server but not in data to update with, will not be deleted.",
         "operationId": "putBulk",
         "parameters": [
@@ -11098,7 +11460,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11106,7 +11470,9 @@
     },
     "/api/2/applicationrole/{key}": {
       "get": {
-        "tags": ["applicationrole"],
+        "tags": [
+          "applicationrole"
+        ],
         "description": "Returns the ApplicationRole with passed key if it exists.",
         "operationId": "get_4",
         "parameters": [
@@ -11144,13 +11510,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["applicationrole"],
+        "tags": [
+          "applicationrole"
+        ],
         "description": "Updates the ApplicationRole with the passed data. Only the groups and default groups setting of the role may be updated. Requests to change the key or the name of the role will be silently ignored.",
         "operationId": "put_2",
         "parameters": [
@@ -11218,7 +11588,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11226,7 +11598,9 @@
     },
     "/api/2/attachment/meta": {
       "get": {
-        "tags": ["attachment"],
+        "tags": [
+          "attachment"
+        ],
         "description": "Returns the meta information for an attachments, specifically if they are enabled and the maximum upload size allowed.",
         "operationId": "getAttachmentMeta",
         "responses": {
@@ -11243,7 +11617,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11251,7 +11627,9 @@
     },
     "/api/2/attachment/{id}": {
       "get": {
-        "tags": ["attachment"],
+        "tags": [
+          "attachment"
+        ],
         "description": "Returns the meta-data for an attachment, including the URI of the actual attached file.",
         "operationId": "getAttachment",
         "parameters": [
@@ -11286,13 +11664,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["attachment"],
+        "tags": [
+          "attachment"
+        ],
         "description": "Remove an attachment from an issue.",
         "operationId": "removeAttachment",
         "parameters": [
@@ -11317,7 +11699,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11325,7 +11709,9 @@
     },
     "/api/2/attachment/{id}/expand/human": {
       "get": {
-        "tags": ["attachment"],
+        "tags": [
+          "attachment"
+        ],
         "description": "Tries to expand an attachment. Output is human-readable and subject to change.",
         "operationId": "expandForHumans",
         "parameters": [
@@ -11363,7 +11749,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11371,7 +11759,9 @@
     },
     "/api/2/attachment/{id}/expand/raw": {
       "get": {
-        "tags": ["attachment"],
+        "tags": [
+          "attachment"
+        ],
         "description": "Tries to expand an attachment. Output is raw and should be backwards-compatible through the course of time.",
         "operationId": "expandForMachines",
         "parameters": [
@@ -11409,7 +11799,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11417,7 +11809,9 @@
     },
     "/api/2/avatar/{type}/system": {
       "get": {
-        "tags": ["avatar"],
+        "tags": [
+          "avatar"
+        ],
         "description": "Returns all system avatars of the given type.",
         "operationId": "getAllSystemAvatars",
         "parameters": [
@@ -11452,7 +11846,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11460,7 +11856,9 @@
     },
     "/api/2/avatar/{type}/temporary": {
       "post": {
-        "tags": ["avatar"],
+        "tags": [
+          "avatar"
+        ],
         "description": "Creates temporary avatar",
         "operationId": "storeTemporaryAvatar",
         "parameters": [
@@ -11516,7 +11914,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11524,7 +11924,9 @@
     },
     "/api/2/avatar/{type}/temporaryCrop": {
       "post": {
-        "tags": ["avatar"],
+        "tags": [
+          "avatar"
+        ],
         "description": "Updates the cropping instructions of the temporary avatar",
         "operationId": "createAvatarFromTemporary",
         "parameters": [
@@ -11559,7 +11961,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11567,7 +11971,9 @@
     },
     "/api/2/cluster/index-snapshot/{nodeId}": {
       "put": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Request current index from node (the request is processed asynchronously)",
         "operationId": "requestCurrentIndexFromNode",
         "parameters": [
@@ -11598,7 +12004,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11606,7 +12014,9 @@
     },
     "/api/2/cluster/node/{nodeId}": {
       "delete": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Delete the node from the cluster if state of node is OFFLINE.",
         "operationId": "deleteNode",
         "parameters": [
@@ -11640,7 +12050,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11648,7 +12060,9 @@
     },
     "/api/2/cluster/node/{nodeId}/offline": {
       "put": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Change the node's state to offline if the node is reporting as active, but is not alive.",
         "operationId": "changeNodeStateToOffline",
         "parameters": [
@@ -11682,7 +12096,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11690,7 +12106,9 @@
     },
     "/api/2/cluster/nodes": {
       "get": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Returns all nodes in cluster.",
         "operationId": "getAllNodes",
         "responses": {
@@ -11713,7 +12131,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11721,7 +12141,9 @@
     },
     "/api/2/cluster/zdu/approve": {
       "post": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Approves the cluster upgrade.",
         "operationId": "approveUpgrade",
         "responses": {
@@ -11737,7 +12159,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11745,7 +12169,9 @@
     },
     "/api/2/cluster/zdu/cancel": {
       "post": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Cancels the ongoing cluster upgrade.",
         "operationId": "cancelUpgrade",
         "responses": {
@@ -11761,7 +12187,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11769,7 +12197,9 @@
     },
     "/api/2/cluster/zdu/retryUpgrade": {
       "post": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Retries the cluster upgrade.",
         "operationId": "acknowledgeErrors",
         "responses": {
@@ -11785,7 +12215,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11793,7 +12225,9 @@
     },
     "/api/2/cluster/zdu/start": {
       "post": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Starts the cluster upgrade.",
         "operationId": "setReadyToUpgrade",
         "responses": {
@@ -11809,7 +12243,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11817,7 +12253,9 @@
     },
     "/api/2/cluster/zdu/state": {
       "get": {
-        "tags": ["cluster"],
+        "tags": [
+          "cluster"
+        ],
         "description": "Returns the current state of the cluster upgrade.",
         "operationId": "getState",
         "responses": {
@@ -11837,7 +12275,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11845,7 +12285,9 @@
     },
     "/api/2/comment/{commentId}/properties": {
       "get": {
-        "tags": ["comment"],
+        "tags": [
+          "comment"
+        ],
         "description": "Returns the keys of all properties for the comment identified by the key or by the id.",
         "operationId": "getCommentPropertiesKeys",
         "parameters": [
@@ -11886,7 +12328,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -11894,7 +12338,9 @@
     },
     "/api/2/comment/{commentId}/properties/{propertyKey}": {
       "get": {
-        "tags": ["comment"],
+        "tags": [
+          "comment"
+        ],
         "description": "Returns the value of the property with a given key from the comment identified by the key or by the id. The user who retrieves the property is required to have permissions to read the comment.",
         "operationId": "getProperty_comment",
         "parameters": [
@@ -11945,13 +12391,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["comment"],
+        "tags": [
+          "comment"
+        ],
         "description": "Sets the value of the specified comment's property.",
         "operationId": "setCommentProperty",
         "parameters": [
@@ -12004,13 +12454,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["comment"],
+        "tags": [
+          "comment"
+        ],
         "description": "Removes the property from the comment identified by the key or by the id. Ths user removing the property is required to have permissions to administer the comment.",
         "operationId": "deleteProperty_2",
         "parameters": [
@@ -12054,7 +12508,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12062,7 +12518,9 @@
     },
     "/api/2/component": {
       "post": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Create a component via POST.",
         "operationId": "createComponent",
         "requestBody": {
@@ -12098,7 +12556,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12106,7 +12566,9 @@
     },
     "/api/2/component/page": {
       "get": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Returns paginated list of filtered active components",
         "operationId": "getPaginatedComponents",
         "parameters": [
@@ -12163,7 +12625,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12171,7 +12635,9 @@
     },
     "/api/2/component/{id}": {
       "get": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Returns a project component.",
         "operationId": "getComponent",
         "parameters": [
@@ -12203,13 +12669,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Modify a component via PUT. Any fields present in the PUT will override existing values. As a convenience, if a field is not present, it is silently ignored.",
         "operationId": "updateComponent",
         "parameters": [
@@ -12254,13 +12724,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Delete a project component.",
         "operationId": "delete",
         "parameters": [
@@ -12300,7 +12774,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12308,7 +12784,9 @@
     },
     "/api/2/component/{id}/relatedIssueCounts": {
       "get": {
-        "tags": ["component"],
+        "tags": [
+          "component"
+        ],
         "description": "Returns counts of issues related to this component.",
         "operationId": "getComponentRelatedIssues",
         "parameters": [
@@ -12340,7 +12818,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12348,7 +12828,9 @@
     },
     "/api/2/configuration": {
       "get": {
-        "tags": ["configuration"],
+        "tags": [
+          "configuration"
+        ],
         "description": "Returns the information if the optional features in Jira are enabled or disabled. If the time tracking is enabled, it also returns the detailed information about time tracking configuration.",
         "operationId": "getConfiguration_1",
         "responses": {
@@ -12368,7 +12850,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12376,7 +12860,9 @@
     },
     "/api/2/customFieldOption/{id}": {
       "get": {
-        "tags": ["customFieldOption"],
+        "tags": [
+          "customFieldOption"
+        ],
         "description": "Returns a full representation of the Custom Field Option that has the given id.",
         "operationId": "getCustomFieldOption",
         "parameters": [
@@ -12408,7 +12894,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12416,7 +12904,9 @@
     },
     "/api/2/customFields": {
       "get": {
-        "tags": ["customFields"],
+        "tags": [
+          "customFields"
+        ],
         "description": "Returns a list of Custom Fields in the given range.",
         "operationId": "getCustomFields",
         "parameters": [
@@ -12519,13 +13009,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["customFields"],
+        "tags": [
+          "customFields"
+        ],
         "description": "Deletes custom fields in bulk.",
         "operationId": "bulkDeleteCustomFields",
         "parameters": [
@@ -12563,7 +13057,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12571,7 +13067,9 @@
     },
     "/api/2/customFields/{customFieldId}/options": {
       "get": {
-        "tags": ["customFields"],
+        "tags": [
+          "customFields"
+        ],
         "description": "Returns custom field's options defined in a given context composed of projects and issue types.",
         "operationId": "getCustomFieldOptions",
         "parameters": [
@@ -12648,7 +13146,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12656,7 +13156,9 @@
     },
     "/api/2/dashboard": {
       "get": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Returns a list of all dashboards, optionally filtering them.",
         "operationId": "list",
         "parameters": [
@@ -12705,7 +13207,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12713,7 +13217,9 @@
     },
     "/api/2/dashboard/{dashboardId}/items/{itemId}/properties": {
       "get": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Returns the keys of all properties for the dashboard item identified by the id.",
         "operationId": "getDashboardPropertiesKeys",
         "parameters": [
@@ -12758,7 +13264,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12766,7 +13274,9 @@
     },
     "/api/2/dashboard/{dashboardId}/items/{itemId}/properties/{propertyKey}": {
       "get": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Returns the value of the property with a given key from the dashboard item identified by the id.",
         "operationId": "getDashboardPropertyValue",
         "parameters": [
@@ -12821,13 +13331,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Sets the value of the property with a given key on the dashboard item identified by the id.",
         "operationId": "setPropertyValue",
         "parameters": [
@@ -12881,13 +13395,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Removes the property from the dashboard item identified by the key or by the id.",
         "operationId": "deleteDashboardProperty",
         "parameters": [
@@ -12938,7 +13456,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12946,7 +13466,9 @@
     },
     "/api/2/dashboard/{id}": {
       "get": {
-        "tags": ["dashboard"],
+        "tags": [
+          "dashboard"
+        ],
         "description": "Returns a single dashboard.",
         "operationId": "getDashboard",
         "parameters": [
@@ -12978,7 +13500,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -12986,7 +13510,9 @@
     },
     "/api/2/email-templates": {
       "get": {
-        "tags": ["email-templates"],
+        "tags": [
+          "email-templates"
+        ],
         "description": "Creates a zip file containing email templates at local home and returns the file.",
         "operationId": "downloadEmailTemplates",
         "responses": {
@@ -13002,13 +13528,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["email-templates"],
+        "tags": [
+          "email-templates"
+        ],
         "description": "Extracts given zip file to temporary templates folder. If the folder already exists it will replace it's content",
         "operationId": "uploadEmailTemplates",
         "requestBody": {
@@ -13034,7 +13564,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13042,7 +13574,9 @@
     },
     "/api/2/email-templates/apply": {
       "post": {
-        "tags": ["email-templates"],
+        "tags": [
+          "email-templates"
+        ],
         "description": "Replaces the current email templates pack with previously uploaded one, if exists.",
         "operationId": "applyEmailTemplates",
         "responses": {
@@ -13058,7 +13592,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13066,7 +13602,9 @@
     },
     "/api/2/email-templates/revert": {
       "post": {
-        "tags": ["email-templates"],
+        "tags": [
+          "email-templates"
+        ],
         "description": "Replaces the current email templates pack with default templates, which are copied over from Jira binaries.",
         "operationId": "revertEmailTemplatesToDefault",
         "responses": {
@@ -13082,7 +13620,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13090,7 +13630,9 @@
     },
     "/api/2/email-templates/types": {
       "get": {
-        "tags": ["email-templates"],
+        "tags": [
+          "email-templates"
+        ],
         "description": "Returns a list of root templates mapped with Event Types. The list can be used to decide which test emails to send.",
         "operationId": "getEmailTypes",
         "responses": {
@@ -13106,7 +13648,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13114,7 +13658,9 @@
     },
     "/api/2/field": {
       "get": {
-        "tags": ["field"],
+        "tags": [
+          "field"
+        ],
         "description": "Returns a list of all fields, both System and Custom",
         "operationId": "getFields",
         "responses": {
@@ -13134,13 +13680,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["field"],
+        "tags": [
+          "field"
+        ],
         "description": "Creates a custom field using a definition",
         "operationId": "createCustomField",
         "requestBody": {
@@ -13172,7 +13722,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13180,7 +13732,9 @@
     },
     "/api/2/filter": {
       "post": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Creates a new filter, and returns newly created filter. Currently sets permissions just using the users default sharing permissions",
         "operationId": "createFilter",
         "parameters": [
@@ -13218,7 +13772,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13226,7 +13782,9 @@
     },
     "/api/2/filter/defaultShareScope": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns the default share scope of the logged-in user",
         "operationId": "getDefaultShareScope",
         "responses": {
@@ -13246,13 +13804,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Sets the default share scope of the logged-in user. Available values are: AUTHENTICATED (for sharing with all logged-in users) and PRIVATE (for no shares).",
         "operationId": "setDefaultShareScope",
         "requestBody": {
@@ -13281,7 +13843,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13289,7 +13853,9 @@
     },
     "/api/2/filter/favourite": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns the favourite filters of the logged-in user",
         "operationId": "getFavouriteFilters",
         "parameters": [
@@ -13318,7 +13884,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13326,7 +13894,9 @@
     },
     "/api/2/filter/{id}": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns a filter given an id",
         "operationId": "getFilter",
         "parameters": [
@@ -13365,13 +13935,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Updates an existing filter, and returns its new value. The following properties of a filter can be updated: 'jql', 'name', 'description'. Additionally, administrators can also update the 'owner' field. To get, set or unset 'favourite', use rest/api/1.0/filters/{id}/favourite with GET, PUT and DELETE methods instead.",
         "operationId": "editFilter",
         "parameters": [
@@ -13419,13 +13993,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Delete a filter",
         "operationId": "deleteFilter",
         "parameters": [
@@ -13453,7 +14031,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13461,7 +14041,9 @@
     },
     "/api/2/filter/{id}/columns": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns the default columns for the given filter. Currently logged in user will be used as the user making such request.",
         "operationId": "defaultColumns_1",
         "parameters": [
@@ -13496,13 +14078,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Sets the default columns for the given filter",
         "operationId": "setColumns_1",
         "parameters": [
@@ -13547,13 +14133,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Resets the columns for the given filter such that the filter no longer has its own column config",
         "operationId": "resetColumns_1",
         "parameters": [
@@ -13578,7 +14168,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13586,7 +14178,9 @@
     },
     "/api/2/filter/{id}/permission": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns all share permissions of the given filter",
         "operationId": "getSharePermissions",
         "parameters": [
@@ -13621,13 +14215,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Adds a share permissions to the given filter. Adding a global permission removes all previous permissions from the filter",
         "operationId": "addSharePermission",
         "parameters": [
@@ -13674,7 +14272,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13682,7 +14282,9 @@
     },
     "/api/2/filter/{id}/permission/{permission-id}": {
       "delete": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Removes a share permissions from the given filter",
         "operationId": "deleteSharePermission",
         "parameters": [
@@ -13718,7 +14320,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13726,7 +14330,9 @@
     },
     "/api/2/filter/{id}/permission/{permissionId}": {
       "get": {
-        "tags": ["filter"],
+        "tags": [
+          "filter"
+        ],
         "description": "Returns a single share permission of the given filter",
         "operationId": "getSharePermission",
         "parameters": [
@@ -13771,7 +14377,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13779,7 +14387,9 @@
     },
     "/api/2/group": {
       "post": {
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "description": "Creates a group by given group parameter",
         "operationId": "createGroup",
         "requestBody": {
@@ -13814,13 +14424,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "description": "Deletes a group by given group parameter",
         "operationId": "removeGroup",
         "parameters": [
@@ -13863,7 +14477,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13871,7 +14487,9 @@
     },
     "/api/2/group/member": {
       "get": {
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "description": "Returns a paginated list of users who are members of the specified group and its subgroups",
         "operationId": "getUsersFromGroup",
         "parameters": [
@@ -13929,7 +14547,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -13937,7 +14557,9 @@
     },
     "/api/2/group/user": {
       "post": {
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "description": "Adds given user to a group",
         "operationId": "addUserToGroup",
         "parameters": [
@@ -13987,13 +14609,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["group"],
+        "tags": [
+          "group"
+        ],
         "description": "Removes given user from a group",
         "operationId": "removeUserFromGroup",
         "parameters": [
@@ -14037,7 +14663,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14045,7 +14673,9 @@
     },
     "/api/2/groups/picker": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "description": "Returns groups with substrings matching a given query",
         "operationId": "findGroups",
         "parameters": [
@@ -14100,7 +14730,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14108,7 +14740,9 @@
     },
     "/api/2/groupuserpicker": {
       "get": {
-        "tags": ["groupuserpicker"],
+        "tags": [
+          "groupuserpicker"
+        ],
         "description": "Returns a list of users and groups matching query with highlighting",
         "operationId": "findUsersAndGroups",
         "parameters": [
@@ -14184,7 +14818,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14192,7 +14828,9 @@
     },
     "/api/2/index-snapshot": {
       "get": {
-        "tags": ["index-snapshot"],
+        "tags": [
+          "index-snapshot"
+        ],
         "description": "Lists available index snapshots absolute paths with timestamps",
         "operationId": "listIndexSnapshot",
         "responses": {
@@ -14212,13 +14850,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["index-snapshot"],
+        "tags": [
+          "index-snapshot"
+        ],
         "description": "Starts taking an index snapshot if no other snapshot creation process is in progress",
         "operationId": "createIndexSnapshot",
         "responses": {
@@ -14241,7 +14883,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14249,7 +14893,9 @@
     },
     "/api/2/index-snapshot/isRunning": {
       "get": {
-        "tags": ["index-snapshot"],
+        "tags": [
+          "index-snapshot"
+        ],
         "description": "Checks if index snapshot creation is currently running",
         "operationId": "isIndexSnapshotRunning",
         "responses": {
@@ -14269,7 +14915,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14277,7 +14925,9 @@
     },
     "/api/2/index/summary": {
       "get": {
-        "tags": ["index"],
+        "tags": [
+          "index"
+        ],
         "description": "Returns a summary of the index condition of the current node",
         "operationId": "getIndexSummary",
         "responses": {
@@ -14297,7 +14947,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14305,7 +14957,9 @@
     },
     "/api/2/issue": {
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Creates an issue or a sub-task from a JSON representation.",
         "operationId": "createIssue",
         "parameters": [
@@ -14346,7 +15000,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14354,7 +15010,9 @@
     },
     "/api/2/issue/archive": {
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Archives a list of issues.",
         "operationId": "archiveIssues",
         "parameters": [
@@ -14403,7 +15061,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14411,7 +15071,9 @@
     },
     "/api/2/issue/bulk": {
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Creates issues or sub-tasks from a JSON representation. Creates many issues in one bulk operation.",
         "operationId": "createIssues",
         "requestBody": {
@@ -14441,7 +15103,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14449,7 +15113,9 @@
     },
     "/api/2/issue/createmeta/{projectIdOrKey}/issuetypes": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the metadata for issue types used for creating issues. Data will not be returned if the user does not have permission to create issues in that project.",
         "operationId": "getCreateIssueMetaProjectIssueTypes",
         "parameters": [
@@ -14499,7 +15165,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14507,7 +15175,9 @@
     },
     "/api/2/issue/createmeta/{projectIdOrKey}/issuetypes/{issueTypeId}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the metadata for issue types used for creating issues. Data will not be returned if the user does not have permission to create issues in that project.",
         "operationId": "getCreateIssueMetaFields",
         "parameters": [
@@ -14567,7 +15237,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14575,7 +15247,9 @@
     },
     "/api/2/issue/picker": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Get issue picker resource",
         "operationId": "getIssuePickerResource",
         "parameters": [
@@ -14648,7 +15322,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14656,7 +15332,9 @@
     },
     "/api/2/issue/{issueIdOrKey}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns a full representation of the issue for the given issue key.",
         "operationId": "getIssue",
         "parameters": [
@@ -14724,13 +15402,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Edits an issue from a JSON representation. The issue can either be updated by setting explicit the field value(s) or by using an operation to change the field value.",
         "operationId": "editIssue",
         "parameters": [
@@ -14777,13 +15459,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Deletes an issue. If the issue has subtasks you must set the parameter deleteSubtasks=true to delete the issue. You cannot delete an issue without its subtasks also being deleted.",
         "operationId": "deleteIssue",
         "parameters": [
@@ -14826,7 +15512,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14834,7 +15522,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/archive": {
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Archives an issue.",
         "operationId": "archiveIssue",
         "parameters": [
@@ -14874,7 +15564,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14882,7 +15574,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/assignee": {
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Assign an issue to a user.",
         "operationId": "assign",
         "parameters": [
@@ -14923,7 +15617,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14931,7 +15627,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/attachments": {
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Add one or more attachments to an issue.",
         "operationId": "addAttachment",
         "parameters": [
@@ -14978,7 +15676,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -14986,7 +15686,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/comment": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns all comments for an issue. Results can be ordered by the 'created' field which means the date a comment was added.",
         "operationId": "getComments",
         "parameters": [
@@ -15054,13 +15756,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Adds a new comment to an issue.",
         "operationId": "addComment",
         "parameters": [
@@ -15111,7 +15817,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15119,7 +15827,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/comment/{id}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns a single comment.",
         "operationId": "getComment",
         "parameters": [
@@ -15170,13 +15880,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Updates an existing comment using its JSON representation.",
         "operationId": "updateComment",
         "parameters": [
@@ -15237,13 +15951,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Deletes an existing comment.",
         "operationId": "deleteComment",
         "parameters": [
@@ -15278,7 +15996,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15286,7 +16006,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/comment/{id}/pin": {
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Pins a comment to the top of the comment list.",
         "operationId": "setPinComment",
         "parameters": [
@@ -15331,7 +16053,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15339,7 +16063,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/editmeta": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the meta data for editing an issue. The fields in the editmeta correspond to the fields in the edit screen for the issue. Fields not in the screen will not be in the editmeta.",
         "operationId": "getEditIssueMeta",
         "parameters": [
@@ -15371,7 +16097,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15379,7 +16107,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/notify": {
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Sends a notification (email) to the list or recipients defined in the request.",
         "operationId": "notify",
         "parameters": [
@@ -15417,7 +16147,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15425,7 +16157,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/pinned-comments": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns all pinned to the issue comments.",
         "operationId": "getPinnedComments",
         "parameters": [
@@ -15457,7 +16191,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15465,7 +16201,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/properties": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the keys of all properties for the issue identified by the key or by the id.",
         "operationId": "getPropertiesKeys_2",
         "parameters": [
@@ -15506,7 +16244,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15514,7 +16254,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/properties/{propertyKey}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the value of the property with a given key from the issue identified by the key or by the id.",
         "operationId": "getIssueProperty",
         "parameters": [
@@ -15565,13 +16307,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Sets the value of the specified issue's property.",
         "operationId": "setIssueProperty",
         "parameters": [
@@ -15632,13 +16378,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Removes the property from the issue identified by the key or by the id.",
         "operationId": "deleteIssueProperty",
         "parameters": [
@@ -15682,7 +16432,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15690,7 +16442,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/remotelink": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Get remote issue links for an issue.",
         "operationId": "getRemoteIssueLinks",
         "parameters": [
@@ -15740,13 +16494,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Creates or updates a remote issue link from a JSON representation. If a globalId is provided and a remote issue link exists with that globalId, the remote issue link is updated. Otherwise, the remote issue link is created.",
         "operationId": "createOrUpdateRemoteIssueLink",
         "parameters": [
@@ -15794,13 +16552,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Delete the remote issue link with the given global id on the issue.",
         "operationId": "deleteRemoteIssueLinkByGlobalId",
         "parameters": [
@@ -15841,7 +16603,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -15849,7 +16613,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/remotelink/{linkId}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Get a remote issue link by its id.",
         "operationId": "getRemoteIssueLinkById",
         "parameters": [
@@ -15900,13 +16666,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Updates a remote issue link from a JSON representation. Any fields not provided are set to null.",
         "operationId": "updateRemoteIssueLink",
         "parameters": [
@@ -15957,13 +16727,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Delete the remote issue link with the given id on the issue.",
         "operationId": "deleteRemoteIssueLinkById",
         "parameters": [
@@ -16004,7 +16778,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16012,7 +16788,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/restore": {
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Restores an archived issue.",
         "operationId": "restoreIssue",
         "parameters": [
@@ -16052,7 +16830,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16060,7 +16840,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/subtask": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns an issue's subtask list",
         "operationId": "getSubTasks",
         "parameters": [
@@ -16095,7 +16877,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16103,7 +16887,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/subtask/move": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Checks if a subtask can be moved",
         "operationId": "canMoveSubTask",
         "parameters": [
@@ -16133,13 +16919,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Reorders an issue's subtasks by moving the subtask at index 'from' to index 'to'.",
         "operationId": "moveSubTasks",
         "parameters": [
@@ -16181,7 +16971,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16189,7 +16981,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/transitions": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Get a list of the transitions possible for this issue by the current user, along with fields that are required and their types.",
         "operationId": "getTransitions",
         "parameters": [
@@ -16230,13 +17024,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Perform a transition on an issue.",
         "operationId": "doTransition",
         "parameters": [
@@ -16277,7 +17075,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16285,7 +17085,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/votes": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "A REST sub-resource representing the voters on the issue.",
         "operationId": "getVotes",
         "parameters": [
@@ -16317,13 +17119,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Adds voter (currently logged user) to particular ticket. You need to be logged in to use this method.",
         "operationId": "addVote",
         "parameters": [
@@ -16348,13 +17154,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Remove your vote from an issue.",
         "operationId": "removeVote",
         "parameters": [
@@ -16379,7 +17189,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16387,7 +17199,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/watchers": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns the list of watchers for the issue with the given key.",
         "operationId": "getIssueWatchers",
         "parameters": [
@@ -16419,13 +17233,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Adds a user to an issue's watcher list.",
         "operationId": "addWatcher_1",
         "parameters": [
@@ -16475,13 +17293,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Removes a user from an issue's watcher list.",
         "operationId": "removeWatcher_1",
         "parameters": [
@@ -16529,7 +17351,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16537,7 +17361,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/worklog": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns all work logs for an issue. Work logs won't be returned if the Log work field is hidden for the project.",
         "operationId": "getIssueWorklog",
         "parameters": [
@@ -16569,13 +17395,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Adds a new worklog entry to an issue.",
         "operationId": "addWorklog",
         "parameters": [
@@ -16647,7 +17477,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16655,7 +17487,9 @@
     },
     "/api/2/issue/{issueIdOrKey}/worklog/{id}": {
       "get": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Returns a specific worklog. The work log won't be returned if the Log work field is hidden for the project.",
         "operationId": "getWorklog",
         "parameters": [
@@ -16697,13 +17531,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Updates an existing worklog entry. Note that:\n- Fields possible for editing are: comment, visibility, started, timeSpent and timeSpentSeconds.\n- Either timeSpent or timeSpentSeconds can be set.\n- Fields which are not set will not be updated.\n- For a request to be valid, it has to have at least one field change.",
         "operationId": "updateWorklog",
         "parameters": [
@@ -16776,13 +17614,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issue"],
+        "tags": [
+          "issue"
+        ],
         "description": "Deletes an existing worklog entry.",
         "operationId": "deleteWorklog",
         "parameters": [
@@ -16847,7 +17689,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16855,7 +17699,9 @@
     },
     "/api/2/issueLink": {
       "post": {
-        "tags": ["issueLink"],
+        "tags": [
+          "issueLink"
+        ],
         "description": "Creates an issue link between two issues.",
         "operationId": "linkIssues",
         "requestBody": {
@@ -16888,7 +17734,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16896,7 +17744,9 @@
     },
     "/api/2/issueLink/{linkId}": {
       "get": {
-        "tags": ["issueLink"],
+        "tags": [
+          "issueLink"
+        ],
         "description": "Returns an issue link with the specified id.",
         "operationId": "getIssueLink",
         "parameters": [
@@ -16937,13 +17787,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issueLink"],
+        "tags": [
+          "issueLink"
+        ],
         "description": "Deletes an issue link with the specified id.",
         "operationId": "deleteIssueLink",
         "parameters": [
@@ -16977,7 +17831,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -16985,7 +17841,9 @@
     },
     "/api/2/issueLinkType": {
       "get": {
-        "tags": ["issueLinkType"],
+        "tags": [
+          "issueLinkType"
+        ],
         "description": "Returns a list of available issue link types, if issue linking is enabled.",
         "operationId": "getIssueLinkTypes",
         "responses": {
@@ -17008,13 +17866,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issueLinkType"],
+        "tags": [
+          "issueLinkType"
+        ],
         "description": "Create a new issue link type.",
         "operationId": "createIssueLinkType",
         "requestBody": {
@@ -17038,7 +17900,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17046,7 +17910,9 @@
     },
     "/api/2/issueLinkType/{issueLinkTypeId}": {
       "get": {
-        "tags": ["issueLinkType"],
+        "tags": [
+          "issueLinkType"
+        ],
         "description": "Returns for a given issue link type id all information about this issue link type.",
         "operationId": "getIssueLinkType",
         "parameters": [
@@ -17084,13 +17950,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issueLinkType"],
+        "tags": [
+          "issueLinkType"
+        ],
         "description": "Update the specified issue link type.",
         "operationId": "updateIssueLinkType",
         "parameters": [
@@ -17129,13 +17999,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issueLinkType"],
+        "tags": [
+          "issueLinkType"
+        ],
         "description": "Delete the specified issue link type.",
         "operationId": "deleteIssueLinkType",
         "parameters": [
@@ -17163,7 +18037,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17171,7 +18047,9 @@
     },
     "/api/2/issuesecurityschemes": {
       "get": {
-        "tags": ["issuesecurityschemes"],
+        "tags": [
+          "issuesecurityschemes"
+        ],
         "description": "Returns all issue security schemes that are defined.",
         "operationId": "getIssueSecuritySchemes",
         "responses": {
@@ -17194,7 +18072,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17202,7 +18082,9 @@
     },
     "/api/2/issuesecurityschemes/{id}": {
       "get": {
-        "tags": ["issuesecurityschemes"],
+        "tags": [
+          "issuesecurityschemes"
+        ],
         "description": "Returns the issue security scheme along with that are defined.",
         "operationId": "getIssueSecurityScheme",
         "parameters": [
@@ -17237,7 +18119,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17245,7 +18129,9 @@
     },
     "/api/2/issuetype": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns a list of all issue types visible to the user",
         "operationId": "getIssueAllTypes",
         "responses": {
@@ -17268,13 +18154,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Creates an issue type from a JSON representation and adds the issue newly created issue type to the default issue type scheme.",
         "operationId": "createIssueType",
         "requestBody": {
@@ -17307,7 +18197,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17315,7 +18207,9 @@
     },
     "/api/2/issuetype/page": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns paginated list of filtered issue types",
         "operationId": "getPaginatedIssueTypes",
         "parameters": [
@@ -17385,7 +18279,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17393,7 +18289,9 @@
     },
     "/api/2/issuetype/{id}": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns a full representation of the issue type that has the given id.",
         "operationId": "getIssueType_1",
         "parameters": [
@@ -17425,13 +18323,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Updates the specified issue type from a JSON representation.",
         "operationId": "updateIssueType",
         "parameters": [
@@ -17479,13 +18381,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Deletes the specified issue type. If the issue type has any associated issues, these issues will be migrated to the alternative issue type specified in the parameter.",
         "operationId": "deleteIssueType",
         "parameters": [
@@ -17519,7 +18425,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17527,7 +18435,9 @@
     },
     "/api/2/issuetype/{id}/alternatives": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns a list of all alternative issue types for the given issue type id.",
         "operationId": "getAlternativeIssueTypes",
         "parameters": [
@@ -17559,7 +18469,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17567,7 +18479,9 @@
     },
     "/api/2/issuetype/{id}/avatar": {
       "post": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Converts temporary avatar into a real avatar",
         "operationId": "createAvatarFromTemporary_1",
         "parameters": [
@@ -17619,7 +18533,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17627,7 +18543,9 @@
     },
     "/api/2/issuetype/{id}/avatar/temporary": {
       "post": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Creates temporary avatar using multipart. The response is sent back as JSON stored in a textarea. This is because\nthe client uses remote iframing to submit avatars using multipart. So we must send them a valid HTML page back from\nwhich the client parses the JSON from.\nCreating a temporary avatar is part of a 3-step process in uploading a new\navatar for an issue type: upload, crop, confirm. This endpoint allows you to use a multipart upload\ninstead of sending the image directly as the request body.\nYou *must* use \"avatar\" as the name of the upload parameter:\ncurl -c cookiejar.txt -X POST -u admin:admin -H \"X-Atlassian-Token: no-check\" \\\n  -F \"avatar=@mynewavatar.png;type=image/png\" \\\n  'http://localhost:8090/jira/rest/api/2/issuetype/1/avatar/temporary'",
         "operationId": "storeTemporaryAvatarUsingMultiPart",
         "parameters": [
@@ -17674,7 +18592,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17682,7 +18602,9 @@
     },
     "/api/2/issuetype/{issueTypeId}/properties": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns the keys of all properties for the issue type identified by the id",
         "operationId": "getPropertyKeys",
         "parameters": [
@@ -17717,7 +18639,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17725,7 +18649,9 @@
     },
     "/api/2/issuetype/{issueTypeId}/properties/{propertyKey}": {
       "get": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Returns the value of the property with a given key from the issue type identified by the id",
         "operationId": "getIssueTypeProperty",
         "parameters": [
@@ -17770,13 +18696,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Sets the value of the specified issue type's property",
         "operationId": "setIssueTypeProperty",
         "parameters": [
@@ -17829,13 +18759,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issuetype"],
+        "tags": [
+          "issuetype"
+        ],
         "description": "Removes the property from the issue type identified by the id",
         "operationId": "deleteIssueTypeProperty",
         "parameters": [
@@ -17873,7 +18807,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17881,7 +18817,9 @@
     },
     "/api/2/issuetypescheme": {
       "get": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Returns a list of all issue type schemes visible to the user. All issue types associated with the scheme will only be returned if an additional query parameter is provided: expand=schemes.issueTypes. Similarly, the default issue type associated with the scheme (if one exists) will only be returned if an additional query parameter is provided: expand=schemes.defaultIssueType. Note that both query parameters can be used together: expand=schemes.issueTypes,schemes.defaultIssueType.",
         "operationId": "getAllIssueTypeSchemes",
         "responses": {
@@ -17904,13 +18842,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Creates an issue type scheme from a JSON representation",
         "operationId": "createIssueTypeScheme",
         "requestBody": {
@@ -17947,7 +18889,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -17955,7 +18899,9 @@
     },
     "/api/2/issuetypescheme/{schemeId}": {
       "get": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Returns a full representation of the issue type scheme that has the given id",
         "operationId": "getIssueTypeScheme",
         "parameters": [
@@ -17993,13 +18939,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Updates the specified issue type scheme from a JSON representation",
         "operationId": "updateIssueTypeScheme",
         "parameters": [
@@ -18051,13 +19001,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Deletes the specified issue type scheme. Any projects associated with this IssueTypeScheme will be automatically associated with the global default IssueTypeScheme.",
         "operationId": "deleteIssueTypeScheme",
         "parameters": [
@@ -18091,7 +19045,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18099,7 +19055,9 @@
     },
     "/api/2/issuetypescheme/{schemeId}/associations": {
       "get": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "For the specified issue type scheme, returns all of the associated projects",
         "operationId": "getAssociatedProjects",
         "parameters": [
@@ -18145,13 +19103,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Associates the given projects with the specified issue type scheme",
         "operationId": "setProjectAssociationsForScheme",
         "parameters": [
@@ -18196,13 +19158,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Adds additional projects to those already associated with the specified issue type scheme",
         "operationId": "addProjectAssociationsToScheme",
         "parameters": [
@@ -18247,13 +19213,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "Removes all project associations for the specified issue type scheme",
         "operationId": "removeAllProjectAssociations",
         "parameters": [
@@ -18284,7 +19254,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18292,7 +19264,9 @@
     },
     "/api/2/issuetypescheme/{schemeId}/associations/{projIdOrKey}": {
       "delete": {
-        "tags": ["issuetypescheme"],
+        "tags": [
+          "issuetypescheme"
+        ],
         "description": "For the specified issue type scheme, removes the given project association",
         "operationId": "removeProjectAssociation",
         "parameters": [
@@ -18333,7 +19307,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18341,7 +19317,9 @@
     },
     "/api/2/jql/autocompletedata": {
       "get": {
-        "tags": ["jql"],
+        "tags": [
+          "jql"
+        ],
         "description": "Returns the auto complete data required for JQL searches",
         "operationId": "getAutoComplete",
         "responses": {
@@ -18364,7 +19342,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18372,7 +19352,9 @@
     },
     "/api/2/jql/autocompletedata/suggestions": {
       "get": {
-        "tags": ["jql"],
+        "tags": [
+          "jql"
+        ],
         "description": "Returns auto complete suggestions for JQL search",
         "operationId": "getFieldAutoCompleteForQueryString",
         "parameters": [
@@ -18423,7 +19405,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18431,7 +19415,9 @@
     },
     "/api/2/licenseValidator": {
       "post": {
-        "tags": ["licenseValidator"],
+        "tags": [
+          "licenseValidator"
+        ],
         "description": "Validates a Jira license",
         "operationId": "validate",
         "requestBody": {
@@ -18460,7 +19446,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18468,7 +19456,9 @@
     },
     "/api/2/monitoring/app": {
       "get": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Checks if App Monitoring is enabled",
         "operationId": "isAppMonitoringEnabled",
         "responses": {
@@ -18485,13 +19475,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Enables or disables App Monitoring",
         "operationId": "setAppMonitoringEnabled",
         "requestBody": {
@@ -18512,7 +19506,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18520,7 +19516,9 @@
     },
     "/api/2/monitoring/ipd": {
       "get": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Checks if IPD Monitoring is enabled",
         "operationId": "isIpdMonitoringEnabled",
         "responses": {
@@ -18537,13 +19535,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Enables or disables IPD Monitoring",
         "operationId": "setAppMonitoringEnabled_1",
         "requestBody": {
@@ -18564,7 +19566,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18572,7 +19576,9 @@
     },
     "/api/2/monitoring/jmx/areMetricsExposed": {
       "get": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Checks if JMX metrics are being exposed",
         "operationId": "areMetricsExposed",
         "responses": {
@@ -18590,7 +19596,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18598,7 +19606,9 @@
     },
     "/api/2/monitoring/jmx/getAvailableMetrics": {
       "get": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Gets the available JMX metrics",
         "operationId": "getAvailableMetrics",
         "responses": {
@@ -18616,7 +19626,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18624,7 +19636,9 @@
     },
     "/api/2/monitoring/jmx/startExposing": {
       "post": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Starts exposing JMX metrics",
         "operationId": "start",
         "responses": {
@@ -18634,7 +19648,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18642,7 +19658,9 @@
     },
     "/api/2/monitoring/jmx/stopExposing": {
       "post": {
-        "tags": ["monitoring"],
+        "tags": [
+          "monitoring"
+        ],
         "description": "Stops exposing JMX metrics",
         "operationId": "stop",
         "responses": {
@@ -18652,7 +19670,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18660,7 +19680,9 @@
     },
     "/api/2/mypermissions": {
       "get": {
-        "tags": ["mypermissions"],
+        "tags": [
+          "mypermissions"
+        ],
         "description": "Returns all permissions in the system and whether the currently logged in user has them. You can optionally provide a specific context to get permissions for (projectKey OR projectId OR issueKey OR issueId)",
         "operationId": "getPermissions",
         "parameters": [
@@ -18724,7 +19746,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18732,7 +19756,9 @@
     },
     "/api/2/mypreferences": {
       "get": {
-        "tags": ["mypreferences"],
+        "tags": [
+          "mypreferences"
+        ],
         "description": "Returns preference of the currently logged in user. Preference key must be provided as input parameter (key). The value is returned exactly as it is. If key parameter is not provided or wrong - status code 404. If value is found  - status code 200.",
         "operationId": "getPreference",
         "parameters": [
@@ -18763,13 +19789,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["mypreferences"],
+        "tags": [
+          "mypreferences"
+        ],
         "description": "Sets preference of the currently logged in user. Preference key must be provided as input parameters (key). Value must be provided as post body. If key or value parameter is not provided - status code 404. If preference is set - status code 204.",
         "operationId": "setPreference",
         "parameters": [
@@ -18799,13 +19829,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["mypreferences"],
+        "tags": [
+          "mypreferences"
+        ],
         "description": "Removes preference of the currently logged in user. Preference key must be provided as input parameters (key). If key parameter is not provided or wrong - status code 404. If preference is unset - status code 204.",
         "operationId": "removePreference",
         "parameters": [
@@ -18825,7 +19859,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18833,7 +19869,9 @@
     },
     "/api/2/myself": {
       "get": {
-        "tags": ["myself"],
+        "tags": [
+          "myself"
+        ],
         "description": "Returns currently logged user. This resource cannot be accessed anonymously",
         "operationId": "getUser",
         "responses": {
@@ -18853,13 +19891,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["myself"],
+        "tags": [
+          "myself"
+        ],
         "description": "Modify currently logged user. The 'value' fields present will override the existing value. Fields skipped in request will not be changed. Only email and display name can be change that way. Requires user password.",
         "operationId": "updateUser",
         "requestBody": {
@@ -18899,7 +19941,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18907,7 +19951,9 @@
     },
     "/api/2/myself/password": {
       "put": {
-        "tags": ["myself"],
+        "tags": [
+          "myself"
+        ],
         "description": "Modify caller password.",
         "operationId": "changeMyPassword",
         "requestBody": {
@@ -18940,7 +19986,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -18948,7 +19996,9 @@
     },
     "/api/2/notificationscheme": {
       "get": {
-        "tags": ["notificationscheme"],
+        "tags": [
+          "notificationscheme"
+        ],
         "description": "Returns a paginated list of notification schemes. In order to access notification scheme, the calling user is\nrequired to have permissions to administer at least one project associated with the requested notification scheme. Each scheme contains\na list of events and recipient configured to receive notifications for these events. Consumer should allow events without recipients to appear in response.\nThe list is ordered by the scheme's name.\nFollow the documentation of /notificationscheme/{id} resource for all details about returned value.\n",
         "operationId": "getNotificationSchemes",
         "parameters": [
@@ -18993,7 +20043,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19001,7 +20053,9 @@
     },
     "/api/2/notificationscheme/{id}": {
       "get": {
-        "tags": ["notificationscheme"],
+        "tags": [
+          "notificationscheme"
+        ],
         "description": "Returns a full representation of the notification scheme for the given id. This resource will return a\nnotification scheme containing a list of events and recipient configured to receive notifications for these events. Consumer\nshould allow events without recipients to appear in response. User accessing\nthe data is required to have permissions to administer at least one project associated with the requested notification scheme.\nNotification recipients can be:\n- current assignee - the value of the notificationType is CurrentAssignee\n- issue reporter - the value of the notificationType is Reporter\n- current user - the value of the notificationType is CurrentUser\n- project lead - the value of the notificationType is ProjectLead\n- component lead - the value of the notificationType is ComponentLead\n- all watchers - the value of the notification type is AllWatchers\n<li>configured user - the value of the notification type is User. Parameter will contain key of the user. Information about the user will be provided\nif <b>user</b> expand parameter is used.\n- configured group - the value of the notification type is Group. Parameter will contain name of the group. Information about the group will be provided\nif <b>group</b> expand parameter is used.\n- configured email address - the value of the notification type is EmailAddress, additionally information about the email will be provided.\n- users or users in groups in the configured custom fields - the value of the notification type is UserCustomField or GroupCustomField. Parameter\nwill contain id of the custom field. Information about the field will be provided if <b>field</b> expand parameter is used.\n- configured project role - the value of the notification type is ProjectRole. Parameter will contain project role id. Information about the project role\nwill be provided if <b>projectRole</b> expand parameter is used.\nPlease see the example for reference.\nThe events can be Jira system events or events configured by administrator. In case of the system events, data about theirs\nids, names and descriptions is provided. In case of custom events, the template event is included as well.",
         "operationId": "getNotificationScheme",
         "parameters": [
@@ -19041,7 +20095,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19049,7 +20105,9 @@
     },
     "/api/2/password/policy": {
       "get": {
-        "tags": ["password"],
+        "tags": [
+          "password"
+        ],
         "description": "Returns the list of requirements for the current password policy. For example, \"The password must have at least 10 characters.\", \"The password must not be similar to the user's name or email address.\", etc.",
         "operationId": "getPasswordPolicy",
         "parameters": [
@@ -19078,7 +20136,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19086,7 +20146,9 @@
     },
     "/api/2/password/policy/createUser": {
       "post": {
-        "tags": ["password"],
+        "tags": [
+          "password"
+        ],
         "description": "Returns a list of statements explaining why the password policy would disallow a proposed password for a new user.\nYou can use this method to test the password policy validation. This could be done prior to an action\nwhere a new user and related password are created, using methods like the ones in\n<a href=\"https://docs.atlassian.com/jira/latest/com/atlassian/jira/bc/user/UserService.html\">UserService</a>.\nFor example, you could use this to validate a password in a create user form in the user interface, as the user enters it.\nThe username and new password must be not empty to perform the validation.\nNote, this method will help you validate against the policy only. It won't check any other validations that might be performed\nwhen creating a new user, e.g. checking whether a user with the same name already exists.\n",
         "operationId": "policyCheckCreateUser",
         "requestBody": {
@@ -19118,7 +20180,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19126,7 +20190,9 @@
     },
     "/api/2/password/policy/updateUser": {
       "post": {
-        "tags": ["password"],
+        "tags": [
+          "password"
+        ],
         "description": "Returns a list of statements explaining why the password policy would disallow a proposed new password for a user with an existing password.\nYou can use this method to test the password policy validation. This could be done prior to an action where the password\nis actually updated, using methods like ChangePassword or ResetPassword.\nFor example, you could use this to validate a password in a change password form in the user interface, as the user enters it.\nThe user must exist and the username and new password must be not empty, to perform the validation.\nNote, this method will help you validate against the policy only. It won't check any other validations that might be performed\nwhen submitting a password change/reset request, e.g. verifying whether the old password is valid.\n",
         "operationId": "policyCheckUpdateUser",
         "requestBody": {
@@ -19161,7 +20227,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19169,7 +20237,9 @@
     },
     "/api/2/permissions": {
       "get": {
-        "tags": ["permissions"],
+        "tags": [
+          "permissions"
+        ],
         "description": "Returns all permissions that are present in the Jira instance - Global, Project and the global ones added by plugins",
         "operationId": "getAllPermissions",
         "responses": {
@@ -19192,7 +20262,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19200,7 +20272,9 @@
     },
     "/api/2/permissionscheme": {
       "get": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Returns a list of all permission schemes. By default only shortened beans are returned. If you want to include permissions of all the schemes, then specify the permissions expand parameter. Permissions will be included also if you specify any other expand parameter.",
         "operationId": "getPermissionSchemes",
         "parameters": [
@@ -19236,13 +20310,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Create a new permission scheme. This method can create schemes with a defined permission set, or without.",
         "operationId": "createPermissionScheme",
         "parameters": [
@@ -19284,7 +20362,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19292,7 +20372,9 @@
     },
     "/api/2/permissionscheme/{permissionSchemeId}/attribute/{attributeKey}": {
       "get": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Returns the attribute for a permission scheme specified by permission scheme id and attribute key.",
         "operationId": "getSchemeAttribute",
         "parameters": [
@@ -19339,7 +20421,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19347,7 +20431,9 @@
     },
     "/api/2/permissionscheme/{permissionSchemeId}/attribute/{key}": {
       "put": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Updates or inserts the attribute for a permission scheme specified by permission scheme id. The attribute consists of the key and the value. The value will be converted to Boolean using Boolean#valueOf.",
         "operationId": "setSchemeAttribute",
         "parameters": [
@@ -19397,7 +20483,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19405,7 +20493,9 @@
     },
     "/api/2/permissionscheme/{schemeId}": {
       "get": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Returns a permission scheme identified by the given id.",
         "operationId": "getPermissionScheme",
         "parameters": [
@@ -19451,13 +20541,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Updates a permission scheme. If the permissions list is present then it will be set in the permission scheme, which basically means it will overwrite any permission grants that existed in the permission scheme. Sending an empty list will remove all permission grants from the permission scheme. To update just the name and description, do not send permissions list at all. To add or remove a single permission grant instead of updating the whole list at once use the {schemeId}/permission/ resource.",
         "operationId": "updatePermissionScheme",
         "parameters": [
@@ -19512,13 +20606,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Deletes a permission scheme identified by the given id.",
         "operationId": "deletePermissionScheme",
         "parameters": [
@@ -19546,7 +20644,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19554,7 +20654,9 @@
     },
     "/api/2/permissionscheme/{schemeId}/permission": {
       "get": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Returns all permission grants of the given permission scheme.",
         "operationId": "getPermissionSchemeGrants",
         "parameters": [
@@ -19600,13 +20702,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Creates a permission grant in a permission scheme.",
         "operationId": "createPermissionGrant",
         "parameters": [
@@ -19658,7 +20764,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19666,7 +20774,9 @@
     },
     "/api/2/permissionscheme/{schemeId}/permission/{permissionId}": {
       "get": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Returns a permission grant identified by the given id.",
         "operationId": "getPermissionSchemeGrant",
         "parameters": [
@@ -19722,13 +20832,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["permissionscheme"],
+        "tags": [
+          "permissionscheme"
+        ],
         "description": "Deletes a permission grant from a permission scheme.",
         "operationId": "deletePermissionSchemeEntity",
         "parameters": [
@@ -19766,7 +20880,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19774,7 +20890,9 @@
     },
     "/api/2/priority": {
       "get": {
-        "tags": ["priority"],
+        "tags": [
+          "priority"
+        ],
         "description": "Returns a list of all issue priorities",
         "operationId": "getPriorities",
         "responses": {
@@ -19794,7 +20912,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19802,7 +20922,9 @@
     },
     "/api/2/priority/page": {
       "get": {
-        "tags": ["priority"],
+        "tags": [
+          "priority"
+        ],
         "description": "Returns a page with list of issue priorities whose names (or their translations) match query",
         "operationId": "getPriorities_1",
         "parameters": [
@@ -19867,7 +20989,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19875,7 +20999,9 @@
     },
     "/api/2/priority/{id}": {
       "get": {
-        "tags": ["priority"],
+        "tags": [
+          "priority"
+        ],
         "description": "Returns an issue priority",
         "operationId": "getPriority",
         "parameters": [
@@ -19909,7 +21035,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -19917,7 +21045,9 @@
     },
     "/api/2/priorityschemes": {
       "get": {
-        "tags": ["priorityschemes"],
+        "tags": [
+          "priorityschemes"
+        ],
         "description": "Returns all priority schemes. All project keys associated with the priority scheme will only be returned if additional query parameter is provided <code>expand=schemes.projectKeys</code>",
         "operationId": "getPrioritySchemes",
         "parameters": [
@@ -19960,13 +21090,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["priorityschemes"],
+        "tags": [
+          "priorityschemes"
+        ],
         "description": "Creates new priority scheme.",
         "operationId": "createPriorityScheme",
         "requestBody": {
@@ -20006,7 +21140,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20014,7 +21150,9 @@
     },
     "/api/2/priorityschemes/{schemeId}": {
       "get": {
-        "tags": ["priorityschemes"],
+        "tags": [
+          "priorityschemes"
+        ],
         "description": "Gets a full representation of a priority scheme in JSON format.",
         "operationId": "getPriorityScheme",
         "parameters": [
@@ -20052,13 +21190,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["priorityschemes"],
+        "tags": [
+          "priorityschemes"
+        ],
         "description": "Updates a priority scheme. Update will be rejected if issue migration would be needed as a result of scheme update. Priority scheme update with migration is possible from the UI.",
         "operationId": "updatePriorityScheme",
         "parameters": [
@@ -20113,13 +21255,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["priorityschemes"],
+        "tags": [
+          "priorityschemes"
+        ],
         "description": "Deletes a priority scheme. All projects using deleted scheme will use default priority scheme afterwards.",
         "operationId": "deletePriorityScheme",
         "parameters": [
@@ -20150,7 +21296,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20158,7 +21306,9 @@
     },
     "/api/2/project": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all projects which are visible for the currently logged in user. If no user is logged in, it returns the list of projects that are visible when using anonymous access.",
         "operationId": "getAllProjects",
         "parameters": [
@@ -20216,13 +21366,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Creates a new project",
         "operationId": "createProject",
         "requestBody": {
@@ -20262,7 +21416,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20270,7 +21426,9 @@
     },
     "/api/2/project/type": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all the project types defined on the Jira instance, not taking into account whether the license to use those project types is valid or not. In case of anonymous checks if they can access at least one project.",
         "operationId": "getAllProjectTypes",
         "responses": {
@@ -20290,7 +21448,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20298,7 +21458,9 @@
     },
     "/api/2/project/type/{projectTypeKey}": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the project type with the given key. In case of anonymous checks if they can access at least one project.",
         "operationId": "getProjectTypeByKey",
         "parameters": [
@@ -20329,7 +21491,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20337,7 +21501,9 @@
     },
     "/api/2/project/type/{projectTypeKey}/accessible": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the project type with the given key, if it is accessible to the logged in user. This takes into account whether the user is licensed on the Application that defines the project type.",
         "operationId": "getAccessibleProjectTypeByKey",
         "parameters": [
@@ -20371,7 +21537,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20379,7 +21547,9 @@
     },
     "/api/2/project/{projectIdOrKey}": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns a full representation of a project in JSON format. All project keys associated with the project will only be returned if <code>expand=projectKeys</code>.",
         "operationId": "getProject",
         "parameters": [
@@ -20418,13 +21588,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Updates a project. Only non null values sent in JSON will be updated in the project. Values available for the assigneeType field are: \"PROJECT_LEAD\" and \"UNASSIGNED\".",
         "operationId": "updateProject",
         "parameters": [
@@ -20483,13 +21657,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Deletes a project",
         "operationId": "deleteProject",
         "parameters": [
@@ -20519,7 +21697,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20527,7 +21707,9 @@
     },
     "/api/2/project/{projectIdOrKey}/archive": {
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Archives a project",
         "operationId": "archiveProject",
         "parameters": [
@@ -20557,7 +21739,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20565,7 +21749,9 @@
     },
     "/api/2/project/{projectIdOrKey}/avatar": {
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Updates an avatar for a project. This is step 3/3 of changing an avatar for a project.",
         "operationId": "updateProjectAvatar",
         "parameters": [
@@ -20606,13 +21792,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Converts the temporary avatar into the final one. This is step 2/3 of changing an avatar for a project:\n- Upload (store temporary avatar)\n- Crop (create avatar from temporary)\n- Update (update project avatar)",
         "operationId": "createAvatarFromTemporary_2",
         "parameters": [
@@ -20663,7 +21853,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20671,7 +21863,9 @@
     },
     "/api/2/project/{projectIdOrKey}/avatar/temporary": {
       "post": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Creates temporary avatar using multipart. The response is sent back as JSON stored in a textarea. This is because\nthe client uses remote iframing to submit avatars using multipart. So we must send them a valid HTML page back from\nwhich the client parses the JSON.\n",
         "operationId": "storeTemporaryAvatarUsingMultiPart_1",
         "parameters": [
@@ -20711,7 +21905,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20719,7 +21915,9 @@
     },
     "/api/2/project/{projectIdOrKey}/avatar/{id}": {
       "delete": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Deletes avatar",
         "operationId": "deleteAvatar",
         "parameters": [
@@ -20756,7 +21954,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20764,7 +21964,9 @@
     },
     "/api/2/project/{projectIdOrKey}/avatars": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all avatars which are visible for the currently logged in user. The avatars are grouped into system and custom.",
         "operationId": "getAllAvatars",
         "parameters": [
@@ -20795,7 +21997,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20803,7 +22007,9 @@
     },
     "/api/2/project/{projectIdOrKey}/components": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Contains a full representation of the specified project's components.",
         "operationId": "getProjectComponents",
         "parameters": [
@@ -20834,7 +22040,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20842,7 +22050,9 @@
     },
     "/api/2/project/{projectIdOrKey}/properties": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the keys of all properties for the project identified by the key or by the id.",
         "operationId": "getPropertiesKeys_3",
         "parameters": [
@@ -20882,7 +22092,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -20890,7 +22102,9 @@
     },
     "/api/2/project/{projectIdOrKey}/properties/{propertyKey}": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the value of the property with a given key from the project identified by the key or by the id.",
         "operationId": "getProperty_5",
         "parameters": [
@@ -20939,13 +22153,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Sets the value of the specified project's property. You can use this resource to store a custom data against the project identified by the key or by the id. The user who stores the data is required to have permissions to administer the project.",
         "operationId": "setProperty_4",
         "parameters": [
@@ -21001,13 +22219,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Removes the property from the project identified by the key or by the id.",
         "operationId": "deleteProjectProperty",
         "parameters": [
@@ -21049,7 +22271,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21057,7 +22281,9 @@
     },
     "/api/2/project/{projectIdOrKey}/restore": {
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Restores an archived project. In case of success restored project should be re-indexed.",
         "operationId": "restoreProject",
         "parameters": [
@@ -21087,7 +22313,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21095,7 +22323,9 @@
     },
     "/api/2/project/{projectIdOrKey}/role": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all roles in the given project Id or key, with links to full details on each role.",
         "operationId": "getProjectRoles",
         "parameters": [
@@ -21119,7 +22349,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21127,7 +22359,9 @@
     },
     "/api/2/project/{projectIdOrKey}/role/{id}": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the details for a given project role in a project.",
         "operationId": "getProjectRole",
         "parameters": [
@@ -21168,13 +22402,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Updates a project role to include the specified actors (users or groups). Can be also used to clear roles to not include any users or groups. For user actors, their usernames should be used.",
         "operationId": "setActors",
         "parameters": [
@@ -21226,13 +22464,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Adds an actor (user or group) to a project role. For user actors, their usernames should be used.",
         "operationId": "addActorUsers",
         "parameters": [
@@ -21287,13 +22529,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Deletes actors (users or groups) from a project role.",
         "operationId": "deleteActor",
         "parameters": [
@@ -21346,7 +22592,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21354,7 +22602,9 @@
     },
     "/api/2/project/{projectIdOrKey}/statuses": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Get all issue types with valid status values for a project",
         "operationId": "getAllStatuses",
         "parameters": [
@@ -21385,7 +22635,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21393,7 +22645,9 @@
     },
     "/api/2/project/{projectIdOrKey}/type/{newProjectTypeKey}": {
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Updates the type of a project",
         "operationId": "updateProjectType",
         "parameters": [
@@ -21442,7 +22696,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21450,7 +22706,9 @@
     },
     "/api/2/project/{projectIdOrKey}/version": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all versions for the specified project. Results are paginated. Results can be ordered by the following fields: sequence, name, startDate, releaseDate.",
         "operationId": "getProjectVersionsPaginated",
         "parameters": [
@@ -21515,7 +22773,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21523,7 +22783,9 @@
     },
     "/api/2/project/{projectIdOrKey}/versions": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Contains a full representation of a the specified project's versions.",
         "operationId": "getProjectVersions",
         "parameters": [
@@ -21562,7 +22824,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21570,7 +22834,9 @@
     },
     "/api/2/project/{projectKeyOrId}/issuesecuritylevelscheme": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the issue security scheme for project.",
         "operationId": "getIssueSecurityScheme_1",
         "parameters": [
@@ -21607,7 +22873,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21615,7 +22883,9 @@
     },
     "/api/2/project/{projectKeyOrId}/notificationscheme": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Gets a notification scheme associated with the project. Follow the documentation of /notificationscheme/{id} resource for all details about returned value.",
         "operationId": "getNotificationScheme_1",
         "parameters": [
@@ -21660,7 +22930,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21668,7 +22940,9 @@
     },
     "/api/2/project/{projectKeyOrId}/permissionscheme": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Gets a permission scheme assigned with a project",
         "operationId": "getAssignedPermissionScheme",
         "parameters": [
@@ -21713,13 +22987,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Assigns a permission scheme with a project",
         "operationId": "assignPermissionScheme",
         "parameters": [
@@ -21775,7 +23053,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21783,7 +23063,9 @@
     },
     "/api/2/project/{projectKeyOrId}/priorityscheme": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Gets a full representation of a priority scheme in JSON format used by specified project. User must be global administrator or project administrator. All project keys associated with the priority scheme will only be returned if additional query parameter is provided expand=projectKeys.",
         "operationId": "getAssignedPriorityScheme",
         "parameters": [
@@ -21817,13 +23099,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Assigns project with priority scheme. Priority scheme assign with migration is possible from the UI. Operation will fail if migration is needed as a result of operation eg. there are issues with priorities invalid in the destination scheme. All project keys associated with the priority scheme will only be returned if additional query parameter is provided expand=projectKeys.",
         "operationId": "assignPriorityScheme",
         "parameters": [
@@ -21871,7 +23157,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21879,7 +23167,9 @@
     },
     "/api/2/project/{projectKeyOrId}/priorityscheme/{schemeId}": {
       "delete": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Unassigns project from priority scheme. Operation will fail for defualt priority scheme, project is not found or project is not associated with provided priority scheme. All project keys associated with the priority scheme will only be returned if additional query parameter is provided expand=projectKeys.",
         "operationId": "unassignPriorityScheme",
         "parameters": [
@@ -21926,7 +23216,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21934,7 +23226,9 @@
     },
     "/api/2/project/{projectKeyOrId}/securitylevel": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns all security levels for the project that the current logged in user has access to. If the user does not have the Set Issue Security permission, the list will be empty.",
         "operationId": "getSecurityLevelsForProject",
         "parameters": [
@@ -21965,7 +23259,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -21973,7 +23269,9 @@
     },
     "/api/2/project/{projectKeyOrId}/workflowscheme": {
       "get": {
-        "tags": ["project"],
+        "tags": [
+          "project"
+        ],
         "description": "Returns the workflow scheme that is associated with requested project.",
         "operationId": "getWorkflowSchemeForProject",
         "parameters": [
@@ -22010,7 +23308,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22018,7 +23318,9 @@
     },
     "/api/2/projectCategory": {
       "get": {
-        "tags": ["projectCategory"],
+        "tags": [
+          "projectCategory"
+        ],
         "description": "Returns all project categories",
         "operationId": "getAllProjectCategories",
         "responses": {
@@ -22038,13 +23340,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["projectCategory"],
+        "tags": [
+          "projectCategory"
+        ],
         "description": "Create a project category.",
         "operationId": "createProjectCategory",
         "requestBody": {
@@ -22081,7 +23387,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22089,7 +23397,9 @@
     },
     "/api/2/projectCategory/{id}": {
       "get": {
-        "tags": ["projectCategory"],
+        "tags": [
+          "projectCategory"
+        ],
         "description": "Returns a full representation of the project category that has the given id.",
         "operationId": "getProjectCategoryById",
         "parameters": [
@@ -22121,13 +23431,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["projectCategory"],
+        "tags": [
+          "projectCategory"
+        ],
         "description": "Modify a project category.",
         "operationId": "updateProjectCategory",
         "parameters": [
@@ -22176,13 +23490,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["projectCategory"],
+        "tags": [
+          "projectCategory"
+        ],
         "description": "Delete a project category.",
         "operationId": "removeProjectCategory",
         "parameters": [
@@ -22213,7 +23531,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22221,7 +23541,9 @@
     },
     "/api/2/projects/picker": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "description": "Returns a list of projects visible to the user where project name and/or key is matching the given query.\nPassing an empty (or whitespace only) query will match no projects. The project matches will\ncontain a field with the query highlighted.\nThe number of projects returned can be controlled by passing a value for 'maxResults', but a hard limit of no\nmore than 100 projects is enforced. The projects are wrapped in a single response object that contains\na header for use in the picker, specifically 'Showing X of Y matching projects' and the total number\nof matches for the query.",
         "operationId": "searchForProjects",
         "parameters": [
@@ -22268,7 +23590,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22276,7 +23600,9 @@
     },
     "/api/2/projectvalidate/key": {
       "get": {
-        "tags": ["projectvalidate"],
+        "tags": [
+          "projectvalidate"
+        ],
         "description": "Validates a project key.",
         "operationId": "getProject_1",
         "parameters": [
@@ -22306,7 +23632,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22314,7 +23642,9 @@
     },
     "/api/2/reindex": {
       "get": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Returns information on the system reindexes. If a reindex is currently taking place then information about this reindex is returned. If there is no active index task, then returns information about the latest reindex task run, otherwise returns a 404 indicating that no reindex has taken place.",
         "operationId": "getReindexInfo",
         "parameters": [
@@ -22345,13 +23675,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Kicks off a reindex. Need Admin permissions to perform this reindex.",
         "operationId": "reindex",
         "parameters": [
@@ -22405,7 +23739,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22413,7 +23749,9 @@
     },
     "/api/2/reindex/issue": {
       "post": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Reindexes one or more individual issues. Indexing is performed synchronously - the call returns when indexing of the issues has completed or a failure occurs.",
         "operationId": "reindexIssues",
         "parameters": [
@@ -22471,7 +23809,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22479,7 +23819,9 @@
     },
     "/api/2/reindex/progress": {
       "get": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Returns information on the system reindexes. If a reindex is currently taking place then information about this reindex is returned. If there is no active index task, then returns information about the latest reindex task run, otherwise returns a 404 indicating that no reindex has taken place.",
         "operationId": "getReindexProgress",
         "parameters": [
@@ -22510,7 +23852,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22518,7 +23862,9 @@
     },
     "/api/2/reindex/request": {
       "post": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Executes any pending reindex requests. Execution is asynchronous - progress of the returned tasks can be monitored through other REST calls.",
         "operationId": "processRequests",
         "responses": {
@@ -22543,7 +23889,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22551,7 +23899,9 @@
     },
     "/api/2/reindex/request/bulk": {
       "get": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Retrieves the progress of multiple reindex requests. Only reindex requests that actually exist will be returned in the results.",
         "operationId": "getProgressBulk",
         "parameters": [
@@ -22584,7 +23934,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22592,7 +23944,9 @@
     },
     "/api/2/reindex/request/{requestId}": {
       "get": {
-        "tags": ["reindex"],
+        "tags": [
+          "reindex"
+        ],
         "description": "Retrieves the progress of a single reindex request.",
         "operationId": "getProgress",
         "parameters": [
@@ -22624,7 +23978,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22632,7 +23988,9 @@
     },
     "/api/2/resolution": {
       "get": {
-        "tags": ["resolution"],
+        "tags": [
+          "resolution"
+        ],
         "description": "Returns a list of all resolutions.",
         "operationId": "getResolutions",
         "responses": {
@@ -22649,7 +24007,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22657,7 +24017,9 @@
     },
     "/api/2/resolution/page": {
       "get": {
-        "tags": ["resolution"],
+        "tags": [
+          "resolution"
+        ],
         "description": "Returns paginated list of filtered resolutions.",
         "operationId": "getPaginatedResolutions",
         "parameters": [
@@ -22705,7 +24067,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22713,7 +24077,9 @@
     },
     "/api/2/resolution/{id}": {
       "get": {
-        "tags": ["resolution"],
+        "tags": [
+          "resolution"
+        ],
         "description": "Returns a resolution.",
         "operationId": "getResolution",
         "parameters": [
@@ -22744,7 +24110,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22752,7 +24120,9 @@
     },
     "/api/2/role": {
       "get": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Get all the ProjectRoles available in Jira. Currently this list is global.",
         "operationId": "getProjectRoles_1",
         "responses": {
@@ -22775,13 +24145,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Creates a new ProjectRole to be available in Jira. The created role does not have any default actors assigned.",
         "operationId": "createProjectRole",
         "requestBody": {
@@ -22821,7 +24195,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -22829,7 +24205,9 @@
     },
     "/api/2/role/{id}": {
       "get": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Get a specific ProjectRole available in Jira.",
         "operationId": "getProjectRolesById",
         "parameters": [
@@ -22867,13 +24245,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Fully updates a roles. Both name and description must be given.",
         "operationId": "fullyUpdateProjectRole",
         "parameters": [
@@ -22923,13 +24305,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Partially updates a roles name or description.",
         "operationId": "partialUpdateProjectRole",
         "parameters": [
@@ -22979,13 +24365,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Deletes a role. May return 403 in the future",
         "operationId": "deleteProjectRole",
         "parameters": [
@@ -23031,7 +24421,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23039,7 +24431,9 @@
     },
     "/api/2/role/{id}/actors": {
       "get": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Gets default actors for the given role.",
         "operationId": "getProjectRoleActorsForRole",
         "parameters": [
@@ -23077,13 +24471,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Adds default actors to the given role. The request data should contain a list of usernames or a list of groups to add.",
         "operationId": "addProjectRoleActorsToRole",
         "parameters": [
@@ -23133,13 +24531,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["role"],
+        "tags": [
+          "role"
+        ],
         "description": "Removes default actor from the given role.",
         "operationId": "deleteProjectRoleActorsFromRole",
         "parameters": [
@@ -23196,7 +24598,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23204,7 +24608,9 @@
     },
     "/api/2/screens": {
       "get": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Adds field or custom field to the default tab.",
         "operationId": "getAllScreens",
         "parameters": [
@@ -23254,7 +24660,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23262,7 +24670,9 @@
     },
     "/api/2/screens/addToDefault/{fieldId}": {
       "post": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Moves field on the given tab.",
         "operationId": "addFieldToDefaultScreen",
         "parameters": [
@@ -23289,7 +24699,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23297,7 +24709,9 @@
     },
     "/api/2/screens/{screenId}/availableFields": {
       "get": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Gets available fields for screen. i.e ones that haven't already been added.",
         "operationId": "getFieldsToAdd",
         "parameters": [
@@ -23332,7 +24746,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23340,7 +24756,9 @@
     },
     "/api/2/screens/{screenId}/tabs": {
       "get": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Returns a list of all tabs for the given screen.",
         "operationId": "getAllTabs",
         "parameters": [
@@ -23383,13 +24801,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Creates tab for given screen.",
         "operationId": "addTab",
         "parameters": [
@@ -23433,7 +24855,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23441,7 +24865,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}": {
       "put": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Renames tab on given screen.",
         "operationId": "renameTab",
         "parameters": [
@@ -23495,13 +24921,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Deletes tab from given screen.",
         "operationId": "deleteTab",
         "parameters": [
@@ -23542,7 +24972,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23550,7 +24982,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}/fields": {
       "get": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Gets all fields for a given tab.",
         "operationId": "getAllFields",
         "parameters": [
@@ -23603,13 +25037,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Adds field to the given tab.",
         "operationId": "addField",
         "parameters": [
@@ -23663,7 +25101,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23671,7 +25111,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}/fields/{id}": {
       "delete": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Removes field from given tab.",
         "operationId": "removeField",
         "parameters": [
@@ -23718,7 +25160,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23726,7 +25170,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}/fields/{id}/move": {
       "post": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Moves field on the given tab.",
         "operationId": "moveField",
         "parameters": [
@@ -23782,7 +25228,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23790,7 +25238,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}/fields/{id}/updateShowWhenEmptyIndicator/{newValue}": {
       "put": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Update 'showWhenEmptyIndicator' for given field on screen.",
         "operationId": "updateShowWhenEmptyIndicator",
         "parameters": [
@@ -23846,7 +25296,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23854,7 +25306,9 @@
     },
     "/api/2/screens/{screenId}/tabs/{tabId}/move/{pos}": {
       "post": {
-        "tags": ["screens"],
+        "tags": [
+          "screens"
+        ],
         "description": "Moves tab position.",
         "operationId": "moveTab",
         "parameters": [
@@ -23902,7 +25356,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -23910,7 +25366,9 @@
     },
     "/api/2/search": {
       "get": {
-        "tags": ["search"],
+        "tags": [
+          "search"
+        ],
         "description": "Searches for issues using JQL.\nSorting\nthe jql parameter is a full <a href=\"http://confluence.atlassian.com/display/JIRA/Advanced+Searching\">JQL</a>\nexpression, and includes an ORDER BY clause.\nThe fields param (which can be specified multiple times) gives a comma-separated list of fields\nto include in the response. This can be used to retrieve a subset of fields.\nA particular field can be excluded by prefixing it with a minus.\nBy default, only navigable (*navigable) fields are returned in this search resource. Note: the default is different\nin the get-issue resource -- the default there all fields (*all).\n*all - include all fields\n*navigable - include just navigable fields\nsummary,comment - include just the summary and comments\n-description - include navigable fields except the description (the default is *navigable for search)\n*all,-comment - include everything except comments\nGET vs POST:\nIf the JQL query is too large to be encoded as a query param you should instead\nPOST to this resource.\nExpanding Issues in the Search Result:\nIt is possible to expand the issues returned by directly specifying the expansion on the expand parameter passed\nin to this resources.\nFor instance, to expand the changelog for all the issues on the search result, it is necessary to\nspecify changelog as one of the values to expand.",
         "operationId": "search_1",
         "parameters": [
@@ -23985,13 +25443,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["search"],
+        "tags": [
+          "search"
+        ],
         "description": "Performs a search using JQL.",
         "operationId": "searchUsingSearchRequest",
         "requestBody": {
@@ -24022,7 +25484,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24030,7 +25494,9 @@
     },
     "/api/2/securitylevel/{id}": {
       "get": {
-        "tags": ["securitylevel"],
+        "tags": [
+          "securitylevel"
+        ],
         "description": "Returns a full representation of the security level that has the given id.",
         "operationId": "getIssuesecuritylevel",
         "parameters": [
@@ -24061,7 +25527,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24069,7 +25537,9 @@
     },
     "/api/2/serverInfo": {
       "get": {
-        "tags": ["serverInfo"],
+        "tags": [
+          "serverInfo"
+        ],
         "description": "Returns general information about the current Jira server.",
         "operationId": "getServerInfo",
         "responses": {
@@ -24086,7 +25556,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24094,7 +25566,9 @@
     },
     "/api/2/settings/baseUrl": {
       "put": {
-        "tags": ["settings"],
+        "tags": [
+          "settings"
+        ],
         "description": "Sets the base URL that is configured for this Jira instance.",
         "operationId": "setBaseURL",
         "requestBody": {
@@ -24117,7 +25591,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24125,7 +25601,9 @@
     },
     "/api/2/settings/columns": {
       "get": {
-        "tags": ["settings"],
+        "tags": [
+          "settings"
+        ],
         "description": "Returns the default system columns for issue navigator. Admin permission will be required.",
         "operationId": "getIssueNavigatorDefaultColumns",
         "responses": {
@@ -24148,13 +25626,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["settings"],
+        "tags": [
+          "settings"
+        ],
         "description": "Sets the default system columns for issue navigator. Admin permission will be required.",
         "operationId": "setIssueNavigatorDefaultColumnsForm",
         "requestBody": {
@@ -24187,7 +25669,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24195,7 +25679,9 @@
     },
     "/api/2/status": {
       "get": {
-        "tags": ["status"],
+        "tags": [
+          "status"
+        ],
         "description": "Returns a list of all statuses",
         "operationId": "getStatuses",
         "responses": {
@@ -24215,7 +25701,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24223,7 +25711,9 @@
     },
     "/api/2/status/page": {
       "get": {
-        "tags": ["status"],
+        "tags": [
+          "status"
+        ],
         "description": "Returns paginated list of filtered statuses",
         "operationId": "getPaginatedStatuses",
         "parameters": [
@@ -24298,7 +25788,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24306,7 +25798,9 @@
     },
     "/api/2/status/{idOrName}": {
       "get": {
-        "tags": ["status"],
+        "tags": [
+          "status"
+        ],
         "description": "Returns a full representation of the Status having the given id or name.",
         "operationId": "getStatus",
         "parameters": [
@@ -24337,7 +25831,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24345,7 +25841,9 @@
     },
     "/api/2/statuscategory": {
       "get": {
-        "tags": ["statuscategory"],
+        "tags": [
+          "statuscategory"
+        ],
         "description": "Returns a list of all status categories",
         "operationId": "getStatusCategories",
         "parameters": [
@@ -24385,7 +25883,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24393,7 +25893,9 @@
     },
     "/api/2/statuscategory/{idOrKey}": {
       "get": {
-        "tags": ["statuscategory"],
+        "tags": [
+          "statuscategory"
+        ],
         "description": "Returns a full representation of the StatusCategory having the given id or key",
         "operationId": "getStatusCategory",
         "parameters": [
@@ -24424,7 +25926,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24432,7 +25936,9 @@
     },
     "/api/2/terminology/entries": {
       "get": {
-        "tags": ["terminology"],
+        "tags": [
+          "terminology"
+        ],
         "description": "Returns a list of all defined names for the default words 'epic' and 'sprint'",
         "operationId": "getAllTerminologyEntries",
         "responses": {
@@ -24449,13 +25955,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["terminology"],
+        "tags": [
+          "terminology"
+        ],
         "description": "Change epic/sprint names from {originalName} to {newName}. The {newName} will be displayed in Jira instead of {originalName}\n{\"originalName\"} must be equal to \"epic\" or \"sprint\".\nThere can be only one entry per unique {\"originalName\"}.\n{\"newName\"} can only consist of alphanumeric characters and spaces e.g. {\"newName\": \"iteration number 2\"}.\n{\"newName\"} must be between 1 to 100 characters.\nIt can't use the already defined {\"newName\"} values or restricted JQL words.\nTo reset {\"newName\"} to the default value, enter the {\"originalName\"} value as the value for {\"newName\"}. For example, if you want to return to {\"originalName\": \"sprint\"}, enter {\"newName\": \"sprint\"}.",
         "operationId": "setTerminologyEntries",
         "requestBody": {
@@ -24482,7 +25992,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24490,7 +26002,9 @@
     },
     "/api/2/terminology/entries/{originalName}": {
       "get": {
-        "tags": ["terminology"],
+        "tags": [
+          "terminology"
+        ],
         "description": "Returns epic or sprint name as specified in the {originalName} path param",
         "operationId": "getTerminologyEntry",
         "parameters": [
@@ -24521,7 +26035,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24529,7 +26045,9 @@
     },
     "/api/2/universal_avatar/type/{type}/owner/{owningObjectId}": {
       "get": {
-        "tags": ["universal_avatar"],
+        "tags": [
+          "universal_avatar"
+        ],
         "description": "Returns a list of all avatars",
         "operationId": "getAvatars",
         "parameters": [
@@ -24569,7 +26087,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24577,7 +26097,9 @@
     },
     "/api/2/universal_avatar/type/{type}/owner/{owningObjectId}/avatar": {
       "post": {
-        "tags": ["universal_avatar"],
+        "tags": [
+          "universal_avatar"
+        ],
         "description": "Creates avatar from temporary",
         "operationId": "createAvatarFromTemporary_3",
         "parameters": [
@@ -24632,7 +26154,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24640,7 +26164,9 @@
     },
     "/api/2/universal_avatar/type/{type}/owner/{owningObjectId}/avatar/{id}": {
       "delete": {
-        "tags": ["universal_avatar"],
+        "tags": [
+          "universal_avatar"
+        ],
         "description": "Deletes avatar",
         "operationId": "deleteAvatar_1",
         "parameters": [
@@ -24689,7 +26215,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24697,7 +26225,9 @@
     },
     "/api/2/universal_avatar/type/{type}/owner/{owningObjectId}/temp": {
       "post": {
-        "tags": ["universal_avatar"],
+        "tags": [
+          "universal_avatar"
+        ],
         "description": "Creates temporary avatar",
         "operationId": "storeTemporaryAvatarUsingMultiPart_2",
         "parameters": [
@@ -24752,7 +26282,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24760,7 +26292,9 @@
     },
     "/api/2/upgrade": {
       "get": {
-        "tags": ["upgrade"],
+        "tags": [
+          "upgrade"
+        ],
         "description": "Returns the result of the last upgrade task.",
         "operationId": "getUpgradeResult",
         "responses": {
@@ -24783,13 +26317,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["upgrade"],
+        "tags": [
+          "upgrade"
+        ],
         "description": "Runs any pending delayed upgrade tasks. Need Admin permissions to do this.",
         "operationId": "runUpgradesNow",
         "responses": {
@@ -24805,7 +26343,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -24813,7 +26353,9 @@
     },
     "/api/2/user": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a user.",
         "operationId": "getUser_1",
         "parameters": [
@@ -24866,13 +26408,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Modify user. The 'value' fields present will override the existing value. Fields skipped in request will not be changed.",
         "operationId": "updateUser_1",
         "parameters": [
@@ -24930,13 +26476,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Create user. By default created user will not be notified with email. If password field is not set then password will be randomly generated.",
         "operationId": "createUser",
         "requestBody": {
@@ -24976,13 +26526,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Removes user and its references (like project roles associations, watches, history). Note: user references will not be removed if multiple User Directories are used and there is a user with the same name existing in another directory (shadowing user).",
         "operationId": "removeUser",
         "parameters": [
@@ -25022,7 +26576,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25030,7 +26586,9 @@
     },
     "/api/2/user/a11y/personal-settings": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns available accessibility personal settings along with `enabled` property that indicates the currently logged-in user preference.",
         "operationId": "getA11yPersonalSettings",
         "responses": {
@@ -25049,7 +26607,9 @@
     },
     "/api/2/user/anonymization": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Validates user anonymization process.",
         "operationId": "validateUserAnonymization",
         "parameters": [
@@ -25083,7 +26643,9 @@
         }
       },
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Schedules a user anonymization process. Requires system admin permission.",
         "operationId": "scheduleUserAnonymization",
         "requestBody": {
@@ -25115,7 +26677,9 @@
     },
     "/api/2/user/anonymization/progress": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns information about a user anonymization operation progress.",
         "operationId": "getProgress_1",
         "parameters": [
@@ -25144,7 +26708,9 @@
     },
     "/api/2/user/anonymization/rerun": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Validates user anonymization re-run process.",
         "operationId": "validateUserAnonymizationRerun",
         "parameters": [
@@ -25201,7 +26767,9 @@
         }
       },
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Schedules a user anonymization process. Requires system admin permission.",
         "operationId": "scheduleUserAnonymizationRerun",
         "requestBody": {
@@ -25233,7 +26801,9 @@
     },
     "/api/2/user/anonymization/unlock": {
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Removes stale user anonymization task, for scenarios when the node that was executing it is no longer alive. Use it only after making sure that the parent node of the task is actually down, and not just having connectivity issues.",
         "operationId": "unlockAnonymization",
         "responses": {
@@ -25257,7 +26827,9 @@
     },
     "/api/2/user/application": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Add user to given application. Admin permission will be required to perform this operation.",
         "operationId": "addUserToApplication_1",
         "parameters": [
@@ -25294,13 +26866,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Remove user from given application. Admin permission will be required to perform this operation.",
         "operationId": "removeUserFromApplication_1",
         "parameters": [
@@ -25337,7 +26913,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25345,7 +26923,9 @@
     },
     "/api/2/user/assignable/multiProjectSearch": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of users that match the search string and can be assigned issues for all the given projects.",
         "operationId": "findBulkAssignableUsers",
         "parameters": [
@@ -25399,7 +26979,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25407,7 +26989,9 @@
     },
     "/api/2/user/assignable/search": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of users that match the search string. This resource cannot be accessed anonymously. Please note that this resource should be called with an issue key when a list of assignable users is retrieved. For create only a project key should be supplied. The list of assignable users may be incorrect if it's called with the project key for editing.",
         "operationId": "findAssignableUsers_1",
         "parameters": [
@@ -25475,7 +27059,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25483,7 +27069,9 @@
     },
     "/api/2/user/avatar": {
       "put": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Updates the avatar for the user.",
         "operationId": "updateUserAvatar_1",
         "parameters": [
@@ -25536,13 +27124,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Converts temporary avatar into a real avatar",
         "operationId": "createAvatarFromTemporary_4",
         "parameters": [
@@ -25595,7 +27187,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25603,7 +27197,9 @@
     },
     "/api/2/user/avatar/temporary": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Creates temporary avatar using multipart. The response is sent back as JSON stored in a textarea. This is because the client uses remote iframing to submit avatars using multipart. So we must send them a valid HTML page back from which the client parses the JSON from.\nCreating a temporary avatar is part of a 3-step process in uploading a new avatar for a user: upload, crop, confirm. This endpoint allows you to use a multipart upload instead of sending the image directly as the request body.\nYou *must* use \"avatar\" as the name of the upload parameter:\ncurl -c cookiejar.txt -X POST -u admin:admin -H \"X-Atlassian-Token: no-check\" \\\n  -F \"avatar=@mynewavatar.png;type=image/png\" \\\n  'http://localhost:8090/jira/rest/api/2/user/avatar/temporary?username=admin'",
         "operationId": "storeTemporaryAvatarUsingMultiPart_3",
         "parameters": [
@@ -25649,7 +27245,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25657,7 +27255,9 @@
     },
     "/api/2/user/avatar/{id}": {
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Deletes avatar",
         "operationId": "deleteAvatar_2",
         "parameters": [
@@ -25696,7 +27296,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25704,7 +27306,9 @@
     },
     "/api/2/user/avatars": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns all avatars which are visible for the currently logged in user.",
         "operationId": "getAllAvatars_1",
         "parameters": [
@@ -25740,7 +27344,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25748,7 +27354,9 @@
     },
     "/api/2/user/columns": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns the default columns for the given user. Admin permission will be required to get columns for a user other than the currently logged in user.",
         "operationId": "defaultColumns",
         "parameters": [
@@ -25784,13 +27392,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "put": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Sets the default columns for the given user. Admin permission will be required to get columns for a user other than the currently logged in user.",
         "operationId": "setColumnsUrlEncoded",
         "requestBody": {
@@ -25827,13 +27439,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Reset the default columns for the given user to the system default. Admin permission will be required to get columns for a user other than the currently logged in user.",
         "operationId": "resetColumns",
         "parameters": [
@@ -25859,7 +27475,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25867,7 +27485,9 @@
     },
     "/api/2/user/duplicated/count": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of users that match the search string. This resource cannot be accessed anonymously.\nDuplicated means that the user has an account in more than one directory\nand either more than one account is active or the only active account does not belong to the directory\nwith the highest priority.\nThe data returned by this endpoint is cached for 10 minutes and the cache is flushed when any User Directory\nis added, removed, enabled, disabled, or synchronized.\nA System Administrator can also flush the cache manually.\nRelated JAC ticket: https://jira.atlassian.com/browse/JRASERVER-68797",
         "operationId": "getDuplicatedUsersCount",
         "parameters": [
@@ -25900,7 +27520,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25908,7 +27530,9 @@
     },
     "/api/2/user/duplicated/list": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns duplicated users mapped to their directories with an indication if their accounts are active or not.\nDuplicated means that the user has an account in more than one directory and either more than one account is active\nor the only active account does not belong to the directory with the highest priority.\nThe data returned by this endpoint is cached for 10 minutes and the cache is flushed when any User Directory\nis added, removed, enabled, disabled, or synchronized.\nA System Administrator can also flush the cache manually.\nRelated JAC ticket: https://jira.atlassian.com/browse/JRASERVER-68797",
         "operationId": "getDuplicatedUsersMapping",
         "parameters": [
@@ -25944,7 +27568,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -25952,7 +27578,9 @@
     },
     "/api/2/user/password": {
       "put": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Modify user password.",
         "operationId": "changeUserPassword",
         "parameters": [
@@ -26003,7 +27631,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26011,7 +27641,9 @@
     },
     "/api/2/user/permission/search": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of active users that match the search string and have all specified permissions for the project or issue. This resource can be accessed by users with ADMINISTER_PROJECT permission for the project or global ADMIN or SYSADMIN rights. This endpoint can cause serious performance issues and will be removed in Jira 9.0.",
         "operationId": "findUsersWithAllPermissions",
         "parameters": [
@@ -26093,7 +27725,9 @@
         "deprecated": true,
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26101,7 +27735,9 @@
     },
     "/api/2/user/picker": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of users matching query with highlighting.",
         "operationId": "findUsersForPicker",
         "parameters": [
@@ -26163,7 +27799,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26171,7 +27809,9 @@
     },
     "/api/2/user/properties": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns the keys of all properties for the user identified by the key or by the id.",
         "operationId": "getPropertiesKeys_4",
         "parameters": [
@@ -26213,7 +27853,9 @@
     },
     "/api/2/user/properties/{propertyKey}": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns the value of the property with a given key from the user identified by the key or by the id.",
         "operationId": "getUserProperty",
         "parameters": [
@@ -26262,7 +27904,9 @@
         }
       },
       "put": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Sets the value of the specified user's property.\nYou can use this resource to store a custom data against the user identified by the key or by the id. The user\nwho stores the data is required to have permissions to administer the user.",
         "operationId": "setProperty_5",
         "parameters": [
@@ -26325,7 +27969,9 @@
         }
       },
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Removes the property from the user identified by the key or by the id. The user who removes the property is required to have permissions to administer the user.",
         "operationId": "deleteUserProperty",
         "parameters": [
@@ -26376,7 +28022,9 @@
     },
     "/api/2/user/search": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Finds users.",
         "operationId": "findUsers",
         "parameters": [
@@ -26446,7 +28094,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26454,7 +28104,9 @@
     },
     "/api/2/user/session/{username}": {
       "delete": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Invalidates session of given user.",
         "operationId": "deleteSession",
         "parameters": [
@@ -26485,7 +28137,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26493,7 +28147,9 @@
     },
     "/api/2/user/viewissue/search": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "description": "Returns a list of active users that match the search string. This resource cannot be accessed anonymously and requires the Browse Users global permission. Given an issue key this resource will provide a list of users that match the search string and have the browse issue permission for the issue provided.",
         "operationId": "findUsersWithBrowsePermission",
         "parameters": [
@@ -26554,7 +28210,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -26562,7 +28220,9 @@
     },
     "/api/2/version": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Retrieve paginated collection of versions matching given query optionally filtered by given project IDs.",
         "operationId": "getPaginatedVersions",
         "parameters": [
@@ -26627,7 +28287,9 @@
         }
       },
       "post": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Creates a version.",
         "operationId": "createVersion",
         "requestBody": {
@@ -26663,7 +28325,9 @@
     },
     "/api/2/version/remotelink": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns the remote version links for a given global ID.",
         "operationId": "getRemoteVersionLinks",
         "parameters": [
@@ -26695,7 +28359,9 @@
     },
     "/api/2/version/{id}": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns a version.",
         "operationId": "getVersion",
         "parameters": [
@@ -26734,7 +28400,9 @@
         }
       },
       "put": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Updates a version.",
         "operationId": "updateVersion",
         "parameters": [
@@ -26774,7 +28442,9 @@
     },
     "/api/2/version/{id}/mergeto/{moveIssuesTo}": {
       "put": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Merge versions",
         "operationId": "merge",
         "parameters": [
@@ -26812,7 +28482,9 @@
     },
     "/api/2/version/{id}/move": {
       "post": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Modify a version's sequence within a project.\nThe move version bean has 2 alternative field value pairs:\n- position: An absolute position, which may have a value of 'First', 'Last', 'Earlier' or 'Later'\n- after: A version to place this version after.  The value should be the self link of another version",
         "operationId": "moveVersion",
         "parameters": [
@@ -26859,7 +28531,9 @@
     },
     "/api/2/version/{id}/relatedIssueCounts": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns a bean containing the number of fixed in and affected issues for the given version.",
         "operationId": "getVersionRelatedIssues",
         "parameters": [
@@ -26892,7 +28566,9 @@
     },
     "/api/2/version/{id}/removeAndSwap": {
       "post": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Delete a project version, removed values will be replaced with ones specified by the parameters.",
         "operationId": "delete_1",
         "parameters": [
@@ -26932,7 +28608,9 @@
     },
     "/api/2/version/{id}/unresolvedIssueCount": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns the number of unresolved issues for the given version",
         "operationId": "getVersionUnresolvedIssues",
         "parameters": [
@@ -26965,7 +28643,9 @@
     },
     "/api/2/version/{versionId}/remotelink": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns the remote version links associated with the given version ID.",
         "operationId": "getRemoteVersionLinksByVersionId",
         "parameters": [
@@ -26996,7 +28676,9 @@
         }
       },
       "post": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Create a remote version link via POST. The link's global ID will be taken from the JSON payload if provided; otherwise, it will be generated.",
         "operationId": "createOrUpdateRemoteVersionLink",
         "parameters": [
@@ -27037,7 +28719,9 @@
         }
       },
       "delete": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Delete all remote version links for a given version ID.",
         "operationId": "deleteRemoteVersionLinksByVersionId",
         "parameters": [
@@ -27066,7 +28750,9 @@
     },
     "/api/2/version/{versionId}/remotelink/{globalId}": {
       "get": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Returns the remote version link associated with the given version ID and global ID.",
         "operationId": "getRemoteVersionLink",
         "parameters": [
@@ -27106,7 +28792,9 @@
         }
       },
       "post": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Create a remote version link via POST using the provided global ID.",
         "operationId": "createOrUpdateRemoteVersionLink_1",
         "parameters": [
@@ -27156,7 +28844,9 @@
         }
       },
       "delete": {
-        "tags": ["version"],
+        "tags": [
+          "version"
+        ],
         "description": "Delete a specific remote version link with the given version ID and global ID.",
         "operationId": "deleteRemoteVersionLink",
         "parameters": [
@@ -27194,8 +28884,10 @@
     },
     "/api/2/workflow": {
       "get": {
-        "tags": ["workflow"],
-        "description": "Returns all workflows. The â\u0080\u009clastModifiedDateâ\u0080\u009d is returned in Jira Complete Date/Time Format (dd/MMM/yy h:mm by default), but can also be returned as a relative date.",
+        "tags": [
+          "workflow"
+        ],
+        "description": "Returns all workflows. The \u00e2\u0080\u009clastModifiedDate\u00e2\u0080\u009d is returned in Jira Complete Date/Time Format (dd/MMM/yy h:mm by default), but can also be returned as a relative date.",
         "operationId": "getAllWorkflows",
         "parameters": [
           {
@@ -27218,7 +28910,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -27226,7 +28920,9 @@
     },
     "/api/2/workflowscheme": {
       "post": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Create a new workflow scheme. The body contains a representation of the new scheme. Values not passed are assumed to be set to their defaults.",
         "operationId": "createScheme",
         "requestBody": {
@@ -27252,7 +28948,9 @@
     },
     "/api/2/workflowscheme/{id}": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the requested workflow scheme to the caller.",
         "operationId": "getById",
         "parameters": [
@@ -27296,7 +28994,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Update the passed workflow scheme. The body of the request is a representation of the workflow scheme. Values not passed are assumed to indicate no change for that field.\nThe passed representation can have its updateDraftIfNeeded flag set to true to indicate that the draft\nshould be created and/or updated when the actual scheme cannot be edited (e.g. when the scheme is being used by\na project). Values not appearing the body will not be touched.",
         "operationId": "update",
         "parameters": [
@@ -27342,7 +29042,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Delete the passed workflow scheme.",
         "operationId": "deleteScheme",
         "parameters": [
@@ -27375,7 +29077,9 @@
     },
     "/api/2/workflowscheme/{id}/createdraft": {
       "post": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Create a draft for the passed scheme. The draft will be a copy of the state of the parent.",
         "operationId": "createDraftForParent",
         "parameters": [
@@ -27412,7 +29116,9 @@
     },
     "/api/2/workflowscheme/{id}/default": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Return the default workflow from the passed workflow scheme.",
         "operationId": "getDefault",
         "parameters": [
@@ -27456,7 +29162,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Set the default workflow for the passed workflow scheme. The passed representation can have its\nupdateDraftIfNeeded flag set to true to indicate that the draft should be created/updated when the actual scheme\ncannot be edited.",
         "operationId": "updateDefault",
         "parameters": [
@@ -27502,7 +29210,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Remove the default workflow from the passed workflow scheme.",
         "operationId": "deleteDefault",
         "parameters": [
@@ -27547,7 +29257,9 @@
     },
     "/api/2/workflowscheme/{id}/draft": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the requested draft workflow scheme to the caller.",
         "operationId": "getDraftById",
         "parameters": [
@@ -27582,7 +29294,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Update a draft workflow scheme. The draft will created if necessary. The body of the request is a representation of the workflow scheme. Values not passed are assumed to indicate no change for that field.",
         "operationId": "updateDraft",
         "parameters": [
@@ -27628,7 +29342,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Delete the passed draft workflow scheme.",
         "operationId": "deleteDraftById",
         "parameters": [
@@ -27658,7 +29374,9 @@
     },
     "/api/2/workflowscheme/{id}/draft/default": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Return the default workflow from the passed draft workflow scheme to the caller.",
         "operationId": "getDraftDefault",
         "parameters": [
@@ -27693,7 +29411,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Set the default workflow for the passed draft workflow scheme.",
         "operationId": "updateDraftDefault",
         "parameters": [
@@ -27739,7 +29459,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Remove the default workflow from the passed draft workflow scheme.",
         "operationId": "deleteDraftDefault",
         "parameters": [
@@ -27776,7 +29498,9 @@
     },
     "/api/2/workflowscheme/{id}/draft/issuetype/{issueType}": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the issue type mapping for the passed draft workflow scheme.",
         "operationId": "getDraftIssueType",
         "parameters": [
@@ -27820,7 +29544,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Set the issue type mapping for the passed draft scheme. The passed representation can have its updateDraftIfNeeded flag set to true to indicate that\nthe draft should be created/updated when the actual scheme cannot be edited.",
         "operationId": "setDraftIssueType",
         "parameters": [
@@ -27875,7 +29601,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Remove the specified issue type mapping from the draft scheme.",
         "operationId": "deleteDraftIssueType",
         "parameters": [
@@ -27921,7 +29649,9 @@
     },
     "/api/2/workflowscheme/{id}/draft/workflow": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the draft workflow mappings or requested mapping to the caller.",
         "operationId": "getDraftWorkflow",
         "parameters": [
@@ -27964,7 +29694,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Update the draft scheme to include the passed mapping. The body is a representation of the workflow mapping. Values not passed are assumed to indicate no change for that field.",
         "operationId": "updateDraftWorkflowMapping",
         "parameters": [
@@ -28015,7 +29747,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Delete the passed workflow from the draft workflow scheme.",
         "operationId": "deleteDraftWorkflowMapping",
         "parameters": [
@@ -28060,7 +29794,9 @@
     },
     "/api/2/workflowscheme/{id}/issuetype/{issueType}": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the issue type mapping for the passed workflow scheme.",
         "operationId": "getIssueType",
         "parameters": [
@@ -28113,7 +29849,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Set the issue type mapping for the passed scheme. The passed representation can have its updateDraftIfNeeded flag set to true to indicate that\nthe draft should be created/updated when the actual scheme cannot be edited.",
         "operationId": "setIssueType",
         "parameters": [
@@ -28168,7 +29906,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Remove the specified issue type mapping from the scheme.",
         "operationId": "deleteWorkflowSchemeIssueType",
         "parameters": [
@@ -28222,7 +29962,9 @@
     },
     "/api/2/workflowscheme/{id}/workflow": {
       "get": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Returns the workflow mappings or requested mapping to the caller for the passed scheme.",
         "operationId": "getWorkflow",
         "parameters": [
@@ -28274,7 +30016,9 @@
         }
       },
       "put": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Update the scheme to include the passed mapping. The body is a representation of the workflow mapping. Values not passed are assumed to indicate no change for that field.\nThe passed representation can have its updateDraftIfNeeded flag set to true to indicate that the draft\nshould be created/updated when the actual scheme cannot be edited.",
         "operationId": "updateWorkflowMapping",
         "parameters": [
@@ -28325,7 +30069,9 @@
         }
       },
       "delete": {
-        "tags": ["workflowscheme"],
+        "tags": [
+          "workflowscheme"
+        ],
         "description": "Delete the passed workflow from the workflow scheme.",
         "operationId": "deleteWorkflowMapping",
         "parameters": [
@@ -28378,7 +30124,9 @@
     },
     "/api/2/worklog/deleted": {
       "get": {
-        "tags": ["worklog"],
+        "tags": [
+          "worklog"
+        ],
         "summary": "Returns worklogs deleted since given time.",
         "description": "Returns worklogs id and delete time of worklogs that was deleted since given time. The returns set of worklogs is limited to 1000 elements. This API will not return worklogs deleted during last minute.",
         "operationId": "getIdsOfWorklogsDeletedSince",
@@ -28410,7 +30158,9 @@
     },
     "/api/2/worklog/list": {
       "post": {
-        "tags": ["worklog"],
+        "tags": [
+          "worklog"
+        ],
         "summary": "Returns worklogs for given ids.",
         "description": "Returns worklogs for given worklog ids. Only worklogs to which the calling user has permissions, will be included in the result. The returns set of worklogs is limited to 1000 elements.",
         "operationId": "getWorklogsForIds",
@@ -28444,7 +30194,9 @@
     },
     "/api/2/worklog/updated": {
       "get": {
-        "tags": ["worklog"],
+        "tags": [
+          "worklog"
+        ],
         "summary": "Returns worklogs updated since given time.",
         "description": "Returns worklogs id and update time of worklogs that was updated since given time. The returns set of worklogs is limited to 1000 elements. This API will not return worklogs updated during last minute.",
         "operationId": "getIdsOfWorklogsModifiedSince",
@@ -28476,7 +30228,9 @@
     },
     "/auth/1/session": {
       "get": {
-        "tags": ["session"],
+        "tags": [
+          "session"
+        ],
         "description": "Returns information about the currently authenticated user's session. If the caller is not authenticated they will get a 401 Unauthorized status code.",
         "operationId": "currentUser",
         "responses": {
@@ -28496,13 +30250,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "post": {
-        "tags": ["session"],
+        "tags": [
+          "session"
+        ],
         "description": "Creates a new session for a user in Jira. Once a session has been successfully created it can be used to access any of Jira's remote APIs and also the web UI by passing the appropriate HTTP Cookie header. Note that it is generally preferrable to use HTTP BASIC authentication with the REST API. However, this resource may be used to mimic the behaviour of Jira's log-in page (e.g. to display log-in errors to a user).",
         "operationId": "login",
         "requestBody": {
@@ -28536,13 +30294,17 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
       },
       "delete": {
-        "tags": ["session"],
+        "tags": [
+          "session"
+        ],
         "description": "Logs the current user out of Jira, destroying the existing session, if any.",
         "operationId": "logout",
         "responses": {
@@ -28555,7 +30317,9 @@
         },
         "security": [
           {
-            "basic": [],
+            "basic": []
+          },
+          {
             "bearerAuth": []
           }
         ]
@@ -28563,7 +30327,9 @@
     },
     "/auth/1/websudo": {
       "delete": {
-        "tags": ["websudo"],
+        "tags": [
+          "websudo"
+        ],
         "summary": "Invalidate the current WebSudo session",
         "description": "This method invalidates the any current WebSudo session.",
         "operationId": "release",


### PR DESCRIPTION
Fix the semantics of the Jira Server 10.0.0 authentication section. Some methods/tasks required both bearer and basic auth. This PR adjusts all methods/tasks to be able to use either authentication type instead of requiring both.