### PR TITLE
feat(junos): add port turn up use case

### DIFF
--- a/Juniper/JUNOS/Projects/Juniper JUNOS.project.json
+++ b/Juniper/JUNOS/Projects/Juniper JUNOS.project.json
@@ -199,261 +199,6 @@
       }
     },
     {
-      "iid": 42,
-      "reference": "6a1de7f998f25fd9d4056c93",
-      "type": "jsonForm",
-      "folder": "/Golden Configuration",
-      "document": {
-        "id": "6a1de7f998f25fd9d4056c93",
-        "created": "2026-06-01T19:52:47.654Z",
-        "createdBy": "mike.elrom@itential.com",
-        "lastUpdated": "2026-06-01T20:13:46.827Z",
-        "lastUpdatedBy": "mike.elrom@itential.com",
-        "name": "Compliance Form",
-        "description": "",
-        "struct": {
-          "type": "array",
-          "items": [
-            {
-              "nodeId": "95e19ca7-6692-4f15-b362-2d4c8fa0d1f4",
-              "type": "string",
-              "title": "Tree Name",
-              "description": "",
-              "placeholder": "Select an item",
-              "required": true,
-              "enum": [],
-              "enumNames": [],
-              "binding": true,
-              "rel": "collection",
-              "targetPointer": "/enum",
-              "customKey": "tree_name",
-              "readOnly": false,
-              "method": "GET",
-              "uniqueItems": false,
-              "base": "/configuration_manager",
-              "href": "/configs",
-              "sourcePointer": "/",
-              "sourceKeyPointer": "/name"
-            },
-            {
-              "nodeId": "0e0602fd-c568-4f7e-81c6-5f4accaf4752",
-              "type": "string",
-              "title": "Tree Version",
-              "description": "",
-              "placeholder": "Enter text",
-              "required": true,
-              "readOnly": false,
-              "binding": false,
-              "rel": "item",
-              "targetPointer": "/default",
-              "customKey": "version",
-              "default": "initial"
-            }
-          ]
-        },
-        "schema": {
-          "title": "Compliance Form",
-          "description": "",
-          "type": "object",
-          "required": [
-            "tree_name",
-            "version"
-          ],
-          "properties": {
-            "tree_name": {
-              "type": "string",
-              "title": "Tree Name",
-              "_id": "/properties/tree_name",
-              "description": "",
-              "enum": [],
-              "enumNames": []
-            },
-            "version": {
-              "type": "string",
-              "title": "Tree Version",
-              "_id": "/properties/version",
-              "description": "",
-              "default": "initial"
-            }
-          }
-        },
-        "uiSchema": {
-          "tree_name": {
-            "ui:placeholder": "Select an item"
-          },
-          "version": {
-            "ui:placeholder": "Enter text"
-          },
-          "ui:order": [
-            "tree_name",
-            "version",
-            "*"
-          ]
-        },
-        "bindingSchema": {
-          "properties": {
-            "tree_name": {
-              "binding:method": "GET",
-              "binding:link": {
-                "$ref": "/links",
-                "rel": "collection"
-              },
-              "binding:target": {
-                "propertyPointer": "/enum"
-              },
-              "binding:hyperSchema": {
-                "type": "object",
-                "base": "/configuration_manager",
-                "links": [
-                  {
-                    "rel": "collection",
-                    "href": "/configs",
-                    "targetMediaType": "application/json",
-                    "targetSchema": {
-                      "$ref": "#"
-                    },
-                    "variables": []
-                  }
-                ]
-              },
-              "binding:source": {
-                "propertyPointer": "/",
-                "keyPointer": "/name"
-              }
-            }
-          }
-        },
-        "validationSchema": {},
-        "version": "2020.1"
-      }
-    },
-    {
-      "iid": 31,
-      "reference": "@6a1de7f998f25fd9d4056c91: Pre and Post Checks",
-      "type": "mopCommandTemplate",
-      "folder": "/Software Upgrade",
-      "document": {
-        "tags": [],
-        "name": "Pre and Post Checks",
-        "description": "Captures pre/post device state for a Junos device. Runs show version, show system storage, show interfaces terse, and show route summary. Rules are sanity-only — the workflow reads commands_results[].response for the actual diff inputs.",
-        "os": "juniper_junos",
-        "passRule": true,
-        "ignoreWarnings": null,
-        "commands": [
-          {
-            "command": "show version",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "Junos:",
-                "eval": "contains",
-                "severity": "error"
-              }
-            ]
-          },
-          {
-            "command": "show system storage",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "/dev/gpt/junos",
-                "eval": "contains",
-                "severity": "error"
-              }
-            ]
-          },
-          {
-            "command": "show interfaces terse",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "",
-                "eval": "contains",
-                "severity": "error"
-              }
-            ]
-          },
-          {
-            "command": "show route summary",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "destinations",
-                "eval": "contains",
-                "severity": "error"
-              }
-            ]
-          }
-        ],
-        "created": 1779675515376,
-        "createdBy": "itential-02",
-        "lastUpdated": 1780344827025,
-        "lastUpdatedBy": "mike.elrom@itential.com"
-      }
-    },
-    {
-      "iid": 36,
-      "reference": "@6a1de7f998f25fd9d4056c91: Reboot",
-      "type": "mopCommandTemplate",
-      "folder": "/Software Upgrade",
-      "document": {
-        "tags": [],
-        "name": "Reboot",
-        "description": "Runs request system software add <image_path> no-validate no-copy, then request system reboot. Reboot response may be partial because SSH terminates.",
-        "os": "juniper_junos",
-        "passRule": true,
-        "ignoreWarnings": null,
-        "commands": [
-          {
-            "command": "request system reboot",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "Shutdown NOW!",
-                "eval": "contains",
-                "severity": "warn"
-              }
-            ]
-          }
-        ],
-        "created": 1779719937714,
-        "createdBy": "6a0c557474e890f65883e175",
-        "lastUpdated": 1780344827162,
-        "lastUpdatedBy": "mike.elrom@itential.com"
-      }
-    },
-    {
-      "iid": 32,
-      "reference": "@6a1de7f998f25fd9d4056c91: Stage Upgrade",
-      "type": "mopCommandTemplate",
-      "folder": "/Software Upgrade",
-      "document": {
-        "tags": [],
-        "name": "Stage Upgrade",
-        "description": "Runs request system software add <image_path> no-validate no-copy, then request system reboot. Reboot response may be partial because SSH terminates.",
-        "os": "juniper_junos",
-        "passRule": true,
-        "ignoreWarnings": null,
-        "commands": [
-          {
-            "command": "request system software add <!image_path!> no-validate no-copy",
-            "passRule": true,
-            "rules": [
-              {
-                "rule": "set will be activated at next reboot",
-                "eval": "contains",
-                "severity": "warn"
-              }
-            ]
-          }
-        ],
-        "created": 1779675515780,
-        "createdBy": "itential-02",
-        "lastUpdated": 1780344827212,
-        "lastUpdatedBy": "mike.elrom@itential.com"
-      }
-    },
-    {
       "iid": 27,
       "reference": "@6a1de7f998f25fd9d4056c91: Verify Image",
       "type": "mopCommandTemplate",
@@ -534,6 +279,101 @@
       }
     },
     {
+      "iid": 31,
+      "reference": "@6a1de7f998f25fd9d4056c91: Pre and Post Checks",
+      "type": "mopCommandTemplate",
+      "folder": "/Software Upgrade",
+      "document": {
+        "tags": [],
+        "name": "Pre and Post Checks",
+        "description": "Captures pre/post device state for a Junos device. Runs show version, show system storage, show interfaces terse, and show route summary. Rules are sanity-only \u2014 the workflow reads commands_results[].response for the actual diff inputs.",
+        "os": "juniper_junos",
+        "passRule": true,
+        "ignoreWarnings": null,
+        "commands": [
+          {
+            "command": "show version",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "Junos:",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show system storage",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "/dev/gpt/junos",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show interfaces terse",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show route summary",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "destinations",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          }
+        ],
+        "created": 1779675515376,
+        "createdBy": "itential-02",
+        "lastUpdated": 1780344827025,
+        "lastUpdatedBy": "mike.elrom@itential.com"
+      }
+    },
+    {
+      "iid": 32,
+      "reference": "@6a1de7f998f25fd9d4056c91: Stage Upgrade",
+      "type": "mopCommandTemplate",
+      "folder": "/Software Upgrade",
+      "document": {
+        "tags": [],
+        "name": "Stage Upgrade",
+        "description": "Runs request system software add <image_path> no-validate no-copy, then request system reboot. Reboot response may be partial because SSH terminates.",
+        "os": "juniper_junos",
+        "passRule": true,
+        "ignoreWarnings": null,
+        "commands": [
+          {
+            "command": "request system software add <!image_path!> no-validate no-copy",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "set will be activated at next reboot",
+                "eval": "contains",
+                "severity": "warn"
+              }
+            ]
+          }
+        ],
+        "created": 1779675515780,
+        "createdBy": "itential-02",
+        "lastUpdated": 1780344827212,
+        "lastUpdatedBy": "mike.elrom@itential.com"
+      }
+    },
+    {
       "iid": 33,
       "reference": "ccebebcc-0955-4202-8fda-32d4845e4a12",
       "type": "workflow",
@@ -556,7 +396,7 @@
               "incoming": {
                 "clusterId": "cluster-itential",
                 "language": "python",
-                "code": "import sys\nimport json\nimport re\n\n# ── Read inputs from stdin (IAG runCode standard) ────────────────────────────\ndata = json.load(sys.stdin)\n\ndevice_results = data.get('device_results', {})\ntarget_version  = data.get('target_version', '')\n\n# ── Extract device name and version from 'show version' output ───────────────\ncommands    = device_results.get('commands_results', [])\ndevice_name = commands[0].get('device') if commands else None\n\nfound_version = None\nfor cmd in commands:\n    if cmd.get('raw', '').strip().lower() == 'show version':\n        response = cmd.get('response', '')\n        match = re.search(r'^Junos:\\s+(\\S+)', response, re.MULTILINE)\n        if match:\n            found_version = match.group(1)\n        break\n\n# ── Build result ─────────────────────────────────────────────────────────────\nif found_version is None:\n    result = {\n        'passed':  False,\n        'found':   None,\n        'target':  target_version,\n        'device':  device_name,\n        'message': \"Could not extract Junos version — 'show version' output missing or malformed.\"\n    }\nelse:\n    passed = found_version == target_version\n    result = {\n        'passed':  passed,\n        'found':   found_version,\n        'target':  target_version,\n        'device':  device_name,\n        'message': (\n            f\"Device '{device_name}' is running Junos {found_version} — matches target {target_version}.\"\n            if passed else\n            f\"Device '{device_name}' is running Junos {found_version} — expected {target_version}.\"\n        )\n    }\n\n# ── Emit JSON to stdout (captured as stdout_json by the platform) ─────────────\nprint(json.dumps(result))",
+                "code": "import sys\nimport json\nimport re\n\n# \u2500\u2500 Read inputs from stdin (IAG runCode standard) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\ndata = json.load(sys.stdin)\n\ndevice_results = data.get('device_results', {})\ntarget_version  = data.get('target_version', '')\n\n# \u2500\u2500 Extract device name and version from 'show version' output \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\ncommands    = device_results.get('commands_results', [])\ndevice_name = commands[0].get('device') if commands else None\n\nfound_version = None\nfor cmd in commands:\n    if cmd.get('raw', '').strip().lower() == 'show version':\n        response = cmd.get('response', '')\n        match = re.search(r'^Junos:\\s+(\\S+)', response, re.MULTILINE)\n        if match:\n            found_version = match.group(1)\n        break\n\n# \u2500\u2500 Build result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nif found_version is None:\n    result = {\n        'passed':  False,\n        'found':   None,\n        'target':  target_version,\n        'device':  device_name,\n        'message': \"Could not extract Junos version \u2014 'show version' output missing or malformed.\"\n    }\nelse:\n    passed = found_version == target_version\n    result = {\n        'passed':  passed,\n        'found':   found_version,\n        'target':  target_version,\n        'device':  device_name,\n        'message': (\n            f\"Device '{device_name}' is running Junos {found_version} \u2014 matches target {target_version}.\"\n            if passed else\n            f\"Device '{device_name}' is running Junos {found_version} \u2014 expected {target_version}.\"\n        )\n    }\n\n# \u2500\u2500 Emit JSON to stdout (captured as stdout_json by the platform) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nprint(json.dumps(result))",
                 "data": {
                   "target_version": "$var.job.formData#/target_version",
                   "device_results": "$var.a2.mop_template_results"
@@ -1970,6 +1810,37 @@
       }
     },
     {
+      "iid": 36,
+      "reference": "@6a1de7f998f25fd9d4056c91: Reboot",
+      "type": "mopCommandTemplate",
+      "folder": "/Software Upgrade",
+      "document": {
+        "tags": [],
+        "name": "Reboot",
+        "description": "Runs request system software add <image_path> no-validate no-copy, then request system reboot. Reboot response may be partial because SSH terminates.",
+        "os": "juniper_junos",
+        "passRule": true,
+        "ignoreWarnings": null,
+        "commands": [
+          {
+            "command": "request system reboot",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "Shutdown NOW!",
+                "eval": "contains",
+                "severity": "warn"
+              }
+            ]
+          }
+        ],
+        "created": 1779719937714,
+        "createdBy": "6a0c557474e890f65883e175",
+        "lastUpdated": 1780344827162,
+        "lastUpdatedBy": "mike.elrom@itential.com"
+      }
+    },
+    {
       "iid": 38,
       "reference": "8bf53e31-fcf7-421d-a217-2c154e5cb96e",
       "type": "workflow",
@@ -2105,7 +1976,7 @@
             "displayName": "TemplateBuilder",
             "variables": {
               "incoming": {
-                "template": "<h2 style=\"font-size:16px;font-family:Arial,sans-serif;margin:0 0 8px 0;\">Golden Config Compliance Report</h2>\n<p style=\"font-size:12px;color:#555;font-family:Arial,sans-serif;\">Batch ID: <strong>{{ batchId }}</strong> &nbsp;|&nbsp; Status: <strong>{{ status }}</strong> &nbsp;|&nbsp; {{ reports | length }} device report(s)</p>\n\n<h3 style=\"font-size:14px;font-family:Arial,sans-serif;border-bottom:1px solid #ddd;padding-bottom:4px;\">Summary</h3>\n<table style=\"border-collapse:collapse;width:100%;font-size:12px;font-family:Arial,sans-serif;margin-bottom:16px;\">\n  <thead>\n    <tr>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Device</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Node Path</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Score</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Grade</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Warnings</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Errors</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Passes</th>\n    </tr>\n  </thead>\n  <tbody>\n  {% for report in reports %}\n    {% if report.grade == 'fail' %}\n      {% set scoreColor = '#c0392b' %}\n      {% set badgeBg = '#fdecea' %}\n      {% set badgeColor = '#c0392b' %}\n      {% set badgeBorder = '#e5b4b1' %}\n    {% else %}\n      {% set scoreColor = '#27ae60' %}\n      {% set badgeBg = '#eafaf1' %}\n      {% set badgeColor = '#27ae60' %}\n      {% set badgeBorder = '#a9dfbf' %}\n    {% endif %}\n    <tr>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.device }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.nodePath }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;color:{{ scoreColor }};\">{{ report.score }}%</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">\n        <span style=\"display:inline-block;padding:2px 7px;border-radius:3px;font-size:11px;font-weight:bold;background:{{ badgeBg }};color:{{ badgeColor }};border:1px solid {{ badgeBorder }};\">{{ report.grade }}</span>\n      </td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.warnings }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.errors }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.passes }}</td>\n    </tr>\n  {% endfor %}\n  </tbody>\n</table>\n\n{% for report in reports %}\n  {% if report.grade == 'fail' %}\n    {% set scoreColor = '#c0392b' %}\n    {% set badgeBg = '#fdecea' %}\n    {% set badgeColor = '#c0392b' %}\n    {% set badgeBorder = '#e5b4b1' %}\n  {% else %}\n    {% set scoreColor = '#27ae60' %}\n    {% set badgeBg = '#eafaf1' %}\n    {% set badgeColor = '#27ae60' %}\n    {% set badgeBorder = '#a9dfbf' %}\n  {% endif %}\n<h3 style=\"font-size:14px;font-family:Arial,sans-serif;border-bottom:1px solid #ddd;padding-bottom:4px;margin-top:16px;\">{{ report.device }} — {{ report.nodePath }}</h3>\n<div style=\"background:#f9f9f9;border:1px solid #ddd;border-radius:4px;padding:10px 14px;margin-bottom:12px;font-family:Arial,sans-serif;font-size:12px;\">\n  Score: <strong style=\"color:{{ scoreColor }};\">{{ report.score }}%</strong> &nbsp;|&nbsp;\n  Grade: <strong style=\"color:{{ badgeColor }};\">{{ report.grade }}</strong> &nbsp;|&nbsp;\n  Warnings: <strong>{{ report.totals.warnings }}</strong> &nbsp;|&nbsp;\n  Errors: <strong>{{ report.totals.errors }}</strong> &nbsp;|&nbsp;\n  Passes: <strong>{{ report.totals.passes }}</strong> &nbsp;|&nbsp;\n  Device Type: <strong>{{ report.deviceType }}</strong> &nbsp;|&nbsp;\n  Timestamp: <strong>{{ report.timestamp }}</strong>\n</div>\n\n{% if report.issues %}\n<table style=\"border-collapse:collapse;width:100%;font-size:12px;font-family:Arial,sans-serif;margin-bottom:16px;\">\n  <thead>\n    <tr>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Severity</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Type</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Required Config (set command)</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Fix Mode</th>\n    </tr>\n  </thead>\n  <tbody>\n  {% for issue in report.issues %}\n    <tr>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.severity }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.type }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\"><code style=\"font-family:monospace;font-size:11px;background:#f8f8f8;padding:2px 5px;border:1px solid #e0e0e0;border-radius:2px;\">{{ issue.spec.words | join(\" \", \"value\") }}</code></td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.spec.fixMode }}</td>\n    </tr>\n  {% endfor %}\n  </tbody>\n</table>\n{% else %}\n<p style=\"color:#27ae60;font-family:Arial,sans-serif;font-size:12px;\">No issues found.</p>\n{% endif %}\n\n{% endfor %}",
+                "template": "<h2 style=\"font-size:16px;font-family:Arial,sans-serif;margin:0 0 8px 0;\">Golden Config Compliance Report</h2>\n<p style=\"font-size:12px;color:#555;font-family:Arial,sans-serif;\">Batch ID: <strong>{{ batchId }}</strong> &nbsp;|&nbsp; Status: <strong>{{ status }}</strong> &nbsp;|&nbsp; {{ reports | length }} device report(s)</p>\n\n<h3 style=\"font-size:14px;font-family:Arial,sans-serif;border-bottom:1px solid #ddd;padding-bottom:4px;\">Summary</h3>\n<table style=\"border-collapse:collapse;width:100%;font-size:12px;font-family:Arial,sans-serif;margin-bottom:16px;\">\n  <thead>\n    <tr>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Device</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Node Path</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Score</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Grade</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Warnings</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Errors</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Passes</th>\n    </tr>\n  </thead>\n  <tbody>\n  {% for report in reports %}\n    {% if report.grade == 'fail' %}\n      {% set scoreColor = '#c0392b' %}\n      {% set badgeBg = '#fdecea' %}\n      {% set badgeColor = '#c0392b' %}\n      {% set badgeBorder = '#e5b4b1' %}\n    {% else %}\n      {% set scoreColor = '#27ae60' %}\n      {% set badgeBg = '#eafaf1' %}\n      {% set badgeColor = '#27ae60' %}\n      {% set badgeBorder = '#a9dfbf' %}\n    {% endif %}\n    <tr>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.device }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.nodePath }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;color:{{ scoreColor }};\">{{ report.score }}%</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">\n        <span style=\"display:inline-block;padding:2px 7px;border-radius:3px;font-size:11px;font-weight:bold;background:{{ badgeBg }};color:{{ badgeColor }};border:1px solid {{ badgeBorder }};\">{{ report.grade }}</span>\n      </td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.warnings }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.errors }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ report.totals.passes }}</td>\n    </tr>\n  {% endfor %}\n  </tbody>\n</table>\n\n{% for report in reports %}\n  {% if report.grade == 'fail' %}\n    {% set scoreColor = '#c0392b' %}\n    {% set badgeBg = '#fdecea' %}\n    {% set badgeColor = '#c0392b' %}\n    {% set badgeBorder = '#e5b4b1' %}\n  {% else %}\n    {% set scoreColor = '#27ae60' %}\n    {% set badgeBg = '#eafaf1' %}\n    {% set badgeColor = '#27ae60' %}\n    {% set badgeBorder = '#a9dfbf' %}\n  {% endif %}\n<h3 style=\"font-size:14px;font-family:Arial,sans-serif;border-bottom:1px solid #ddd;padding-bottom:4px;margin-top:16px;\">{{ report.device }} \u2014 {{ report.nodePath }}</h3>\n<div style=\"background:#f9f9f9;border:1px solid #ddd;border-radius:4px;padding:10px 14px;margin-bottom:12px;font-family:Arial,sans-serif;font-size:12px;\">\n  Score: <strong style=\"color:{{ scoreColor }};\">{{ report.score }}%</strong> &nbsp;|&nbsp;\n  Grade: <strong style=\"color:{{ badgeColor }};\">{{ report.grade }}</strong> &nbsp;|&nbsp;\n  Warnings: <strong>{{ report.totals.warnings }}</strong> &nbsp;|&nbsp;\n  Errors: <strong>{{ report.totals.errors }}</strong> &nbsp;|&nbsp;\n  Passes: <strong>{{ report.totals.passes }}</strong> &nbsp;|&nbsp;\n  Device Type: <strong>{{ report.deviceType }}</strong> &nbsp;|&nbsp;\n  Timestamp: <strong>{{ report.timestamp }}</strong>\n</div>\n\n{% if report.issues %}\n<table style=\"border-collapse:collapse;width:100%;font-size:12px;font-family:Arial,sans-serif;margin-bottom:16px;\">\n  <thead>\n    <tr>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Severity</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Type</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Required Config (set command)</th>\n      <th style=\"background:#f0f0f0;text-align:left;padding:6px 8px;border:1px solid #ccc;\">Fix Mode</th>\n    </tr>\n  </thead>\n  <tbody>\n  {% for issue in report.issues %}\n    <tr>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.severity }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.type }}</td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\"><code style=\"font-family:monospace;font-size:11px;background:#f8f8f8;padding:2px 5px;border:1px solid #e0e0e0;border-radius:2px;\">{{ issue.spec.words | join(\" \", \"value\") }}</code></td>\n      <td style=\"padding:6px 8px;border:1px solid #ddd;font-size:12px;\">{{ issue.spec.fixMode }}</td>\n    </tr>\n  {% endfor %}\n  </tbody>\n</table>\n{% else %}\n<p style=\"color:#27ae60;font-family:Arial,sans-serif;font-size:12px;\">No issues found.</p>\n{% endif %}\n\n{% endfor %}",
                 "variables": "$var.509b.runComplianceBatchResult",
                 "castDataType": "string"
               },
@@ -2701,7 +2572,7 @@
             "displayName": "TemplateBuilder",
             "variables": {
               "incoming": {
-                "template": "{#-\n  NetBox -> IAG5 Inventory Template — JUNOS / Hybrid\n  Filters: active Junos devices with an IP.\nAdjust as desired, make sure to set passwords with SECRETS\n-#}\n\n{% set junos_slugs = ['juniper-junos', 'vsrx'] %}\n\n{% set credentials = {'user': 'itential', 'password': 'password'} %}\n\n{% set device_overrides = {} %}\n\n{% set netmiko_opts = {\n    'banner_timeout':        60,\n    'session_timeout':       300,\n    'read_timeout_override': 600,\n    'conn_timeout':          60,\n    'global_delay_factor':   3,\n    'enable_fast_mode':      false\n} %}\n\n{% set netconf_opts = {\n    'port':               830,\n    'timeout':            30,\n    'lock_timeout':       60,\n    'lock_poll_interval': 2,\n    'command_timeout': 600,\n    'config_format':  'set'\n} %}\n\n[\n{%- set ns = namespace(first=true) %}\n{%- for device in body.results %}\n\n  {%- set nb_platform = (device.platform.slug if device.platform else device.device_type.slug) or '' %}\n\n  {%- if device.primary_ip4 %}\n    {%- set ip_address = device.primary_ip4.address.split('/')[0] %}\n  {%- elif device.config_context and device.config_context.ipAddress %}\n    {%- set ip_address = device.config_context.ipAddress %}\n  {%- else %}\n    {%- set ip_address = '' %}\n  {%- endif %}\n\n  {%- set creds = device_overrides.get(device.name, credentials) %}\n\n  {%- set driver_options = {'netmiko': netmiko_opts, 'netconf': netconf_opts} %}\n\n  {%- if ip_address and nb_platform in junos_slugs and device.status and device.status.value == 'active' %}\n{{ \",\" if not ns.first else \"\" }}\n{%- set ns.first = false %}\n  {\n    \"name\": \"{{ device.name }}\",\n    \"attributes\": {\n      \"itential_host\":           \"{{ ip_address }}\",\n      \"itential_port\":           22,\n      \"itential_driver\":         \"netmiko\",\n      \"itential_platform\":       \"juniper_junos\",\n      \"itential_user\":           \"{{ creds.user }}\",\n      \"itential_password\":       \"{{ creds.password }}\",\n      \"itential_driver_options\": {{ driver_options | tojson }}\n    },\n    \"tags\": [\n      \"{{ (device.role.slug if device.role else 'unknown') }}\",\n      \"{{ (device.site.slug if device.site else 'unknown') }}\",\n      \"{{ (device.status.value if device.status else 'unknown') }}\",\n      \"driver:netmiko\",\n      \"platform:juniper_junos\",\n      \"transport:cli+netconf\"\n    ]\n  }\n  {%- endif %}\n{%- endfor %}\n]\n",
+                "template": "{#-\n  NetBox -> IAG5 Inventory Template \u2014 JUNOS / Hybrid\n  Filters: active Junos devices with an IP.\nAdjust as desired, make sure to set passwords with SECRETS\n-#}\n\n{% set junos_slugs = ['juniper-junos', 'vsrx'] %}\n\n{% set credentials = {'user': 'itential', 'password': 'password'} %}\n\n{% set device_overrides = {} %}\n\n{% set netmiko_opts = {\n    'banner_timeout':        60,\n    'session_timeout':       300,\n    'read_timeout_override': 600,\n    'conn_timeout':          60,\n    'global_delay_factor':   3,\n    'enable_fast_mode':      false\n} %}\n\n{% set netconf_opts = {\n    'port':               830,\n    'timeout':            30,\n    'lock_timeout':       60,\n    'lock_poll_interval': 2,\n    'command_timeout': 600,\n    'config_format':  'set'\n} %}\n\n[\n{%- set ns = namespace(first=true) %}\n{%- for device in body.results %}\n\n  {%- set nb_platform = (device.platform.slug if device.platform else device.device_type.slug) or '' %}\n\n  {%- if device.primary_ip4 %}\n    {%- set ip_address = device.primary_ip4.address.split('/')[0] %}\n  {%- elif device.config_context and device.config_context.ipAddress %}\n    {%- set ip_address = device.config_context.ipAddress %}\n  {%- else %}\n    {%- set ip_address = '' %}\n  {%- endif %}\n\n  {%- set creds = device_overrides.get(device.name, credentials) %}\n\n  {%- set driver_options = {'netmiko': netmiko_opts, 'netconf': netconf_opts} %}\n\n  {%- if ip_address and nb_platform in junos_slugs and device.status and device.status.value == 'active' %}\n{{ \",\" if not ns.first else \"\" }}\n{%- set ns.first = false %}\n  {\n    \"name\": \"{{ device.name }}\",\n    \"attributes\": {\n      \"itential_host\":           \"{{ ip_address }}\",\n      \"itential_port\":           22,\n      \"itential_driver\":         \"netmiko\",\n      \"itential_platform\":       \"juniper_junos\",\n      \"itential_user\":           \"{{ creds.user }}\",\n      \"itential_password\":       \"{{ creds.password }}\",\n      \"itential_driver_options\": {{ driver_options | tojson }}\n    },\n    \"tags\": [\n      \"{{ (device.role.slug if device.role else 'unknown') }}\",\n      \"{{ (device.site.slug if device.site else 'unknown') }}\",\n      \"{{ (device.status.value if device.status else 'unknown') }}\",\n      \"driver:netmiko\",\n      \"platform:juniper_junos\",\n      \"transport:cli+netconf\"\n    ]\n  }\n  {%- endif %}\n{%- endfor %}\n]\n",
                 "variables": {},
                 "castDataType": "object"
               },
@@ -3120,6 +2991,1211 @@
         "tags": [],
         "groups": [],
         "migrationVersion": 7
+      }
+    },
+    {
+      "iid": 42,
+      "reference": "6a1de7f998f25fd9d4056c93",
+      "type": "jsonForm",
+      "folder": "/Golden Configuration",
+      "document": {
+        "id": "6a1de7f998f25fd9d4056c93",
+        "created": "2026-06-01T19:52:47.654Z",
+        "createdBy": "mike.elrom@itential.com",
+        "lastUpdated": "2026-06-01T20:13:46.827Z",
+        "lastUpdatedBy": "mike.elrom@itential.com",
+        "name": "Compliance Form",
+        "description": "",
+        "struct": {
+          "type": "array",
+          "items": [
+            {
+              "nodeId": "95e19ca7-6692-4f15-b362-2d4c8fa0d1f4",
+              "type": "string",
+              "title": "Tree Name",
+              "description": "",
+              "placeholder": "Select an item",
+              "required": true,
+              "enum": [],
+              "enumNames": [],
+              "binding": true,
+              "rel": "collection",
+              "targetPointer": "/enum",
+              "customKey": "tree_name",
+              "readOnly": false,
+              "method": "GET",
+              "uniqueItems": false,
+              "base": "/configuration_manager",
+              "href": "/configs",
+              "sourcePointer": "/",
+              "sourceKeyPointer": "/name"
+            },
+            {
+              "nodeId": "0e0602fd-c568-4f7e-81c6-5f4accaf4752",
+              "type": "string",
+              "title": "Tree Version",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "customKey": "version",
+              "default": "initial"
+            }
+          ]
+        },
+        "schema": {
+          "title": "Compliance Form",
+          "description": "",
+          "type": "object",
+          "required": [
+            "tree_name",
+            "version"
+          ],
+          "properties": {
+            "tree_name": {
+              "type": "string",
+              "title": "Tree Name",
+              "_id": "/properties/tree_name",
+              "description": "",
+              "enum": [],
+              "enumNames": []
+            },
+            "version": {
+              "type": "string",
+              "title": "Tree Version",
+              "_id": "/properties/version",
+              "description": "",
+              "default": "initial"
+            }
+          }
+        },
+        "uiSchema": {
+          "tree_name": {
+            "ui:placeholder": "Select an item"
+          },
+          "version": {
+            "ui:placeholder": "Enter text"
+          },
+          "ui:order": [
+            "tree_name",
+            "version",
+            "*"
+          ]
+        },
+        "bindingSchema": {
+          "properties": {
+            "tree_name": {
+              "binding:method": "GET",
+              "binding:link": {
+                "$ref": "/links",
+                "rel": "collection"
+              },
+              "binding:target": {
+                "propertyPointer": "/enum"
+              },
+              "binding:hyperSchema": {
+                "type": "object",
+                "base": "/configuration_manager",
+                "links": [
+                  {
+                    "rel": "collection",
+                    "href": "/configs",
+                    "targetMediaType": "application/json",
+                    "targetSchema": {
+                      "$ref": "#"
+                    },
+                    "variables": []
+                  }
+                ]
+              },
+              "binding:source": {
+                "propertyPointer": "/",
+                "keyPointer": "/name"
+              }
+            }
+          }
+        },
+        "validationSchema": {},
+        "version": "2020.1"
+      }
+    },
+    {
+      "iid": 44,
+      "type": "workflow",
+      "reference": "3e29ac6b-ef29-4728-b164-d4ab594526a6",
+      "folder": "/Port Turn Up",
+      "document": {
+        "name": "Port Turn Up",
+        "description": "make sure when this is called that the input is an object called formData. That formData object will have the following as it's JSON object {\n  \"device\": \"aws-lab-junos\",\n  \"target_version\": \"22.4R2.8\",\n  \"image_path\": \"/var/tmp/junos-install-vsrx3-x86-64-22.4R2.8.tgz\",\n  \"image_sha256\": \"8d486921598bb89afd3ab54dcf8fa7cb80423c3977ddaa86dd15e84f13d465b2\"\n}",
+        "tasks": {
+          "6476": {
+            "name": "getDevice",
+            "canvasName": "getDevice",
+            "summary": "Get Device Details",
+            "description": "Get detailed information for a specific device, based on its device name",
+            "location": "Application",
+            "locationType": null,
+            "app": "ConfigurationManager",
+            "type": "automatic",
+            "displayName": "ConfigurationManager",
+            "variables": {
+              "incoming": {
+                "name": "$var.job.formData#/device"
+              },
+              "outgoing": {
+                "device": ""
+              },
+              "decorators": [
+                {
+                  "type": "query",
+                  "pointer": "/incoming/name",
+                  "displayPath": ".device"
+                }
+              ]
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": -360
+            }
+          },
+          "workflow_start": {
+            "name": "workflow_start",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": -468
+            }
+          },
+          "a2": {
+            "name": "RunCommandTemplate",
+            "canvasName": "RunCommandTemplate",
+            "summary": "Port Turn Up Pre Check",
+            "description": "Captures show version, system storage, interfaces, route summary",
+            "location": "Application",
+            "locationType": null,
+            "app": "MOP",
+            "type": "automatic",
+            "displayName": "MOP",
+            "variables": {
+              "incoming": {
+                "template": "@6a138e0000000000ffff0001: Port Turn Up Pre Check",
+                "variables": "$var.job.formData",
+                "devices": "$var.job.formData#/device"
+              },
+              "outgoing": {
+                "mop_template_results": "$var.job.preCheckOutput"
+              },
+              "error": "",
+              "decorators": [
+                {
+                  "type": "query",
+                  "pointer": "/incoming/devices",
+                  "displayPath": ".device"
+                }
+              ]
+            },
+            "groups": [],
+            "actor": "Pronghorn",
+            "scheduled": false,
+            "nodeLocation": {
+              "x": 0,
+              "y": -156
+            }
+          },
+          "b1": {
+            "name": "backUpDevice",
+            "canvasName": "backUpDevice",
+            "summary": "Backup Running Config (pre)",
+            "description": "",
+            "location": "Application",
+            "locationType": null,
+            "app": "ConfigurationManager",
+            "type": "automatic",
+            "displayName": "ConfigurationManager",
+            "variables": {
+              "incoming": {
+                "name": "$var.job.formData#/device",
+                "options": {}
+              },
+              "outgoing": {
+                "status": null
+              },
+              "error": "",
+              "decorators": [
+                {
+                  "type": "query",
+                  "pointer": "/incoming/name",
+                  "displayPath": ".device"
+                }
+              ]
+            },
+            "groups": [],
+            "actor": "Pronghorn",
+            "scheduled": false,
+            "nodeLocation": {
+              "x": 0,
+              "y": 84
+            }
+          },
+          "workflow_end": {
+            "name": "workflow_end",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 876
+            }
+          },
+          "d768": {
+            "name": "evaluation",
+            "canvasName": "evaluation",
+            "summary": "Eval Pre-check",
+            "description": "Run an evaluation",
+            "location": "Application",
+            "locationType": null,
+            "app": "WorkFlowEngine",
+            "type": "operation",
+            "displayName": "WorkFlowEngine",
+            "variables": {
+              "incoming": {
+                "all_true_flag": false,
+                "evaluation_groups": [
+                  {
+                    "all_true_flag": false,
+                    "evaluations": [
+                      {
+                        "operand_1": {
+                          "task": "a2",
+                          "variable": "mop_template_results"
+                        },
+                        "operand_2": {
+                          "task": "static",
+                          "variable": true
+                        },
+                        "operator": "==",
+                        "query": "result",
+                        "rightQuery": ""
+                      }
+                    ]
+                  }
+                ],
+                "options": ""
+              },
+              "outgoing": {
+                "return_value": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": -36
+            }
+          },
+          "f215": {
+            "name": "RunCommandTemplate",
+            "canvasName": "RunCommandTemplate",
+            "summary": "Post Check",
+            "description": "Captures show version, system storage, interfaces, route summary",
+            "location": "Application",
+            "locationType": null,
+            "app": "MOP",
+            "type": "automatic",
+            "displayName": "MOP",
+            "variables": {
+              "incoming": {
+                "template": "@6a138e0000000000ffff0001: Port Turn Up Post Check",
+                "variables": "$var.job.formData",
+                "devices": "$var.job.formData#/device"
+              },
+              "outgoing": {
+                "mop_template_results": "$var.job.postCheckResults"
+              },
+              "error": "",
+              "decorators": [
+                {
+                  "type": "query",
+                  "pointer": "/incoming/devices",
+                  "displayPath": ".device"
+                }
+              ]
+            },
+            "groups": [],
+            "actor": "Pronghorn",
+            "scheduled": false,
+            "nodeLocation": {
+              "x": 0,
+              "y": 648
+            }
+          },
+          "6d1a": {
+            "name": "evaluation",
+            "canvasName": "evaluation",
+            "summary": "Eval Post-check",
+            "description": "Run an evaluation",
+            "location": "Application",
+            "locationType": null,
+            "app": "WorkFlowEngine",
+            "type": "operation",
+            "displayName": "WorkFlowEngine",
+            "variables": {
+              "incoming": {
+                "all_true_flag": false,
+                "evaluation_groups": [
+                  {
+                    "all_true_flag": false,
+                    "evaluations": [
+                      {
+                        "operand_1": {
+                          "task": "f215",
+                          "variable": "mop_template_results"
+                        },
+                        "operand_2": {
+                          "task": "static",
+                          "variable": true
+                        },
+                        "operator": "==",
+                        "query": "result",
+                        "rightQuery": ""
+                      }
+                    ]
+                  }
+                ],
+                "options": ""
+              },
+              "outgoing": {
+                "return_value": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 768
+            }
+          },
+          "3cf3": {
+            "name": "runService",
+            "canvasName": "runService",
+            "summary": "Send Config",
+            "description": "Run an IAG5 service given its name and any parameters passed to the service itself.",
+            "location": "Application",
+            "locationType": null,
+            "app": "GatewayManager",
+            "type": "automatic",
+            "displayName": "GatewayManager",
+            "variables": {
+              "incoming": {
+                "serviceName": "junos-netconf-send-config",
+                "clusterId": "cluster-itential",
+                "params": {
+                  "config": "$var.ac95.renderedTemplate",
+                  "confirm_timeout": 10,
+                  "confirmed": false,
+                  "dry_run": false,
+                  "lock_timeout": 30
+                },
+                "inventory": "$var.26a0.renderedTemplate"
+              },
+              "outgoing": {
+                "result": ""
+              },
+              "decorators": []
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 300
+            }
+          },
+          "ac95": {
+            "name": "renderJinja2TemplateWithCast",
+            "canvasName": "renderJinja2TemplateWithCast",
+            "summary": "Render Jinja2 Template With Data Cast",
+            "description": "Renders jinja2 template output with data cast.",
+            "location": "Application",
+            "locationType": null,
+            "app": "TemplateBuilder",
+            "type": "automatic",
+            "displayName": "TemplateBuilder",
+            "variables": {
+              "incoming": {
+                "name": "@6a138e0000000000ffff0001: 802.1Q Sub Interface",
+                "variables": "$var.job.formData",
+                "castDataType": "string"
+              },
+              "outgoing": {
+                "renderedTemplate": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 192
+            }
+          },
+          "26a0": {
+            "name": "renderJinja2ContextWithCast",
+            "canvasName": "renderJinja2ContextWithCast",
+            "summary": "Inventory Object",
+            "description": "Renders jinja2 Context output with data cast.",
+            "location": "Application",
+            "locationType": null,
+            "app": "TemplateBuilder",
+            "type": "automatic",
+            "displayName": "TemplateBuilder",
+            "variables": {
+              "incoming": {
+                "template": "[\n  { \n    \"inventory\": \"{{name.split('::')[0]}}\",\n    \"nodeNames\": [\n        \"{{name.split('::')[1]}}\"\n    ]\n  }\n]",
+                "variables": "$var.6476.device",
+                "castDataType": "object"
+              },
+              "outgoing": {
+                "renderedTemplate": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": -264
+            }
+          },
+          "908f": {
+            "name": "evaluation",
+            "canvasName": "evaluation",
+            "summary": "Eval Send Config",
+            "description": "Run an evaluation",
+            "location": "Application",
+            "locationType": null,
+            "app": "WorkFlowEngine",
+            "type": "operation",
+            "displayName": "WorkFlowEngine",
+            "variables": {
+              "incoming": {
+                "all_true_flag": false,
+                "evaluation_groups": [
+                  {
+                    "all_true_flag": false,
+                    "evaluations": [
+                      {
+                        "operand_1": {
+                          "task": "962d",
+                          "variable": "textObject"
+                        },
+                        "operand_2": {
+                          "task": "static",
+                          "variable": true
+                        },
+                        "operator": "==",
+                        "query": ".success",
+                        "rightQuery": ""
+                      }
+                    ]
+                  }
+                ],
+                "options": ""
+              },
+              "outgoing": {
+                "return_value": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 540
+            }
+          },
+          "962d": {
+            "name": "parse",
+            "canvasName": "parse",
+            "summary": "Parse stdout",
+            "description": "Parses a JSON string, constructing the JavaScript value or object described by the string.",
+            "location": "Application",
+            "locationType": null,
+            "app": "WorkFlowEngine",
+            "type": "automatic",
+            "displayName": "String",
+            "variables": {
+              "incoming": {
+                "text": "$var.3cf3.result#/result/stdout"
+              },
+              "outgoing": {
+                "textObject": ""
+              },
+              "decorators": [
+                {
+                  "type": "query",
+                  "pointer": "/incoming/text",
+                  "displayPath": ".result.stdout"
+                }
+              ]
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": 420
+            }
+          }
+        },
+        "transitions": {
+          "6476": {
+            "26a0": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "workflow_start": {
+            "6476": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "a2": {
+            "d768": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "b1": {
+            "ac95": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "workflow_end": {},
+          "d768": {
+            "b1": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "f215": {
+            "6d1a": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "6d1a": {
+            "workflow_end": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "3cf3": {
+            "962d": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "ac95": {
+            "3cf3": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "26a0": {
+            "a2": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "908f": {
+            "f215": {
+              "state": "success",
+              "type": "standard"
+            }
+          },
+          "962d": {
+            "908f": {
+              "state": "success",
+              "type": "standard"
+            }
+          }
+        },
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "formData": {
+              "anyOf": [
+                {
+                  "title": "name",
+                  "type": "string",
+                  "examples": [
+                    "xr9kv-atl"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "examples": [
+                    {
+                      "device_name": "Cisco IOS-XR"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": [
+                      "Cisco ASA",
+                      "Cisco NX-OS"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "formData"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "formData": {
+              "anyOf": [
+                {
+                  "title": "name",
+                  "type": "string",
+                  "examples": [
+                    "xr9kv-atl"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "examples": [
+                    {
+                      "device_name": "Cisco IOS-XR"
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": [
+                      "Cisco ASA",
+                      "Cisco NX-OS"
+                    ]
+                  }
+                }
+              ]
+            },
+            "_id": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{24}$"
+            },
+            "initiator": {
+              "type": "string"
+            },
+            "preCheckOutput": {
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "type": "string",
+                  "examples": [
+                    "show version"
+                  ]
+                },
+                "all_pass_flag": {
+                  "type": "boolean"
+                },
+                "evaluated": {
+                  "type": "string",
+                  "examples": [
+                    "show version"
+                  ]
+                },
+                "parameters": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "rule": {
+                        "type": "string",
+                        "examples": [
+                          "show version"
+                        ]
+                      },
+                      "eval": {
+                        "type": "string",
+                        "examples": [
+                          "contains"
+                        ]
+                      },
+                      "raw": {
+                        "type": "string",
+                        "examples": [
+                          "show version"
+                        ]
+                      },
+                      "result": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "rule",
+                      "eval"
+                    ]
+                  }
+                },
+                "device": {
+                  "type": "string",
+                  "examples": [
+                    "Nokia SR-OS"
+                  ]
+                },
+                "response": {
+                  "type": "string",
+                  "examples": [
+                    "version: 10.0.0"
+                  ]
+                },
+                "result": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "postCheckResults": {
+              "type": "object",
+              "properties": {
+                "raw": {
+                  "type": "string",
+                  "examples": [
+                    "show version"
+                  ]
+                },
+                "all_pass_flag": {
+                  "type": "boolean"
+                },
+                "evaluated": {
+                  "type": "string",
+                  "examples": [
+                    "show version"
+                  ]
+                },
+                "parameters": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "rule": {
+                        "type": "string",
+                        "examples": [
+                          "show version"
+                        ]
+                      },
+                      "eval": {
+                        "type": "string",
+                        "examples": [
+                          "contains"
+                        ]
+                      },
+                      "raw": {
+                        "type": "string",
+                        "examples": [
+                          "show version"
+                        ]
+                      },
+                      "result": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "rule",
+                      "eval"
+                    ]
+                  }
+                },
+                "device": {
+                  "type": "string",
+                  "examples": [
+                    "Nokia SR-OS"
+                  ]
+                },
+                "response": {
+                  "type": "string",
+                  "examples": [
+                    "version: 10.0.0"
+                  ]
+                },
+                "result": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "scenarios": [],
+        "tags": [],
+        "type": "automation",
+        "canvasVersion": 3,
+        "font_size": 12,
+        "migrationVersion": 7,
+        "createdVersion": "6.4.0",
+        "lastUpdatedVersion": "5.55.5",
+        "last_updated": "2026-06-02T02:42:23.880Z",
+        "preAutomationTime": 0,
+        "sla": 0,
+        "uuid": "9769f0c9-2da1-4061-a009-1c1459849733",
+        "last_updated_by": {
+          "provenance": "CloudAAA",
+          "username": "mike.elrom@itential.com",
+          "firstname": "Mike",
+          "inactive": false
+        },
+        "created": "1970-01-01T00:00:00.000Z",
+        "groups": []
+      }
+    },
+    {
+      "iid": 45,
+      "type": "template",
+      "folder": "/Port Turn Up",
+      "reference": "6a1e30c698f25fd9d4056ca4",
+      "document": {
+        "_id": "6a1e30c698f25fd9d4056ca4",
+        "name": "802.1Q Sub Interface",
+        "description": "",
+        "type": "jinja2",
+        "group": "Juniper JUNOS",
+        "command": "",
+        "template": "set interfaces {{ interface }} vlan-tagging\nset interfaces {{ interface }} unit {{ vlan_id }} description \"{{ description }}\"\nset interfaces {{ interface }} unit {{ vlan_id }} vlan-id {{ vlan_id }}\nset interfaces {{ interface }} unit {{ vlan_id }} family inet address {{ ip_address }}\nset security zones security-zone {{ zone }} interfaces {{ interface }}.{{ vlan_id }}\n",
+        "data": "{\n  \"interface\": \"ge-0/0/0\",\n  \"vlan_id\": 100,\n  \"description\": \"CORP LAN\",\n  \"ip_address\": \"192.168.100.1/24\",\n  \"zone\": \"trust\"\n}\n",
+        "created": "2026-06-02T01:24:22.337Z",
+        "lastUpdated": "2026-06-02T01:30:42.946Z",
+        "createdBy": {
+          "_id": "6a0c557474e890f65883e175",
+          "provenance": "CloudAAA",
+          "username": "mike.elrom@itential.com",
+          "firstname": "Mike",
+          "inactive": false,
+          "email": "mike.elrom@itential.com"
+        },
+        "lastUpdatedBy": {
+          "_id": "6a0c557474e890f65883e175",
+          "provenance": "CloudAAA",
+          "username": "mike.elrom@itential.com",
+          "firstname": "Mike",
+          "inactive": false,
+          "email": "mike.elrom@itential.com"
+        }
+      }
+    },
+    {
+      "iid": 46,
+      "type": "jsonForm",
+      "folder": "/Port Turn Up",
+      "reference": "6a1e325462b073861f971612",
+      "document": {
+        "id": "6a1e325462b073861f971612",
+        "created": "2026-06-02T01:31:00.689Z",
+        "createdBy": "mike.elrom@itential.com",
+        "lastUpdated": "2026-06-02T02:32:47.662Z",
+        "lastUpdatedBy": "mike.elrom@itential.com",
+        "name": "8021.Q Sub Interface Form",
+        "description": "",
+        "struct": {
+          "type": "object",
+          "description": "",
+          "items": [
+            {
+              "nodeId": "1ce2213f-8804-41a3-961b-4fe82d1834f5",
+              "type": "string",
+              "title": "Device",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "default": "aws-lab-junos"
+            },
+            {
+              "nodeId": "152dff76-28ec-4162-8dca-338dd7e17bb1",
+              "type": "string",
+              "title": "Interface",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "default": "ge-0/0/0"
+            },
+            {
+              "nodeId": "6b723497-01b2-46f8-b2f6-976a3ffdf714",
+              "type": "string",
+              "title": "VLAN ID",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "customKey": "vlan_id",
+              "default": "100"
+            },
+            {
+              "nodeId": "6eaf9ad6-5633-4a26-852d-a8d6be11fc88",
+              "type": "string",
+              "title": "Description",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "default": "CORP LAN"
+            },
+            {
+              "nodeId": "b73ebfd6-0dd9-4036-82b5-666bceddbde2",
+              "type": "string",
+              "title": "IP Address",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": false,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "customKey": "ip_address",
+              "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}\\/(8|16|24|2[89]|3[012])$",
+              "default": "192.168.100.1/24"
+            },
+            {
+              "nodeId": "c30b8f00-6de8-46bb-96d9-6126d117e10d",
+              "type": "string",
+              "title": "zone",
+              "description": "",
+              "placeholder": "Enter text",
+              "required": true,
+              "readOnly": false,
+              "binding": false,
+              "rel": "item",
+              "targetPointer": "/default",
+              "default": "trust"
+            }
+          ]
+        },
+        "schema": {
+          "title": "8021.Q Sub Interface Form",
+          "description": "",
+          "type": "object",
+          "required": [
+            "device",
+            "interface",
+            "vlan_id",
+            "description",
+            "zone"
+          ],
+          "properties": {
+            "device": {
+              "type": "string",
+              "title": "Device",
+              "_id": "/properties/device",
+              "description": "",
+              "default": "aws-lab-junos"
+            },
+            "interface": {
+              "type": "string",
+              "title": "Interface",
+              "_id": "/properties/interface",
+              "description": "",
+              "default": "ge-0/0/0"
+            },
+            "vlan_id": {
+              "type": "string",
+              "title": "VLAN ID",
+              "_id": "/properties/vlan_id",
+              "description": "",
+              "default": "100"
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "_id": "/properties/description",
+              "description": "",
+              "default": "CORP LAN"
+            },
+            "ip_address": {
+              "type": "string",
+              "title": "IP Address",
+              "_id": "/properties/ip_address",
+              "description": "",
+              "default": "192.168.100.1/24",
+              "pattern": "^(\\d{1,3}\\.){3}\\d{1,3}\\/(8|16|24|2[89]|3[012])$"
+            },
+            "zone": {
+              "type": "string",
+              "title": "zone",
+              "_id": "/properties/zone",
+              "description": "",
+              "default": "trust"
+            }
+          }
+        },
+        "uiSchema": {
+          "device": {
+            "ui:placeholder": "Enter text"
+          },
+          "interface": {
+            "ui:placeholder": "Enter text"
+          },
+          "vlan_id": {
+            "ui:placeholder": "Enter text"
+          },
+          "description": {
+            "ui:placeholder": "Enter text"
+          },
+          "ip_address": {
+            "ui:placeholder": "Enter text"
+          },
+          "zone": {
+            "ui:placeholder": "Enter text"
+          },
+          "ui:order": [
+            "device",
+            "interface",
+            "vlan_id",
+            "description",
+            "ip_address",
+            "zone",
+            "*"
+          ]
+        },
+        "bindingSchema": {},
+        "validationSchema": {},
+        "version": "2020.1"
+      }
+    },
+    {
+      "iid": 47,
+      "type": "mopCommandTemplate",
+      "reference": "@6a138e0000000000ffff0001: Port Turn Up Pre Check",
+      "folder": "/Port Turn Up",
+      "document": {
+        "tags": [],
+        "name": "Port Turn Up Pre Check",
+        "description": "Captures pre/post device state for a Junos device. Runs show version, show system storage, show interfaces terse, and show route summary. Rules are sanity-only \u2014 the workflow reads commands_results[].response for the actual diff inputs.",
+        "os": "juniper_junos",
+        "passRule": true,
+        "ignoreWarnings": null,
+        "commands": [
+          {
+            "command": "show configuration interfaces <!interface!>",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show security zones <!zone!>",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show route table inet.0",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          }
+        ],
+        "created": 1780364670141,
+        "createdBy": "6a0c557474e890f65883e175",
+        "lastUpdated": 1780368429689,
+        "lastUpdatedBy": "mike.elrom@itential.com"
+      }
+    },
+    {
+      "iid": 48,
+      "type": "mopCommandTemplate",
+      "reference": "@6a138e0000000000ffff0001: Port Turn Up Post Check",
+      "folder": "/Port Turn Up",
+      "document": {
+        "tags": [],
+        "name": "Port Turn Up Post Check",
+        "description": "Captures pre/post device state for a Junos device. Runs show version, show system storage, show interfaces terse, and show route summary. Rules are sanity-only \u2014 the workflow reads commands_results[].response for the actual diff inputs.",
+        "os": "juniper_junos",
+        "passRule": true,
+        "ignoreWarnings": null,
+        "commands": [
+          {
+            "command": "show configuration interfaces <!interface!>",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show security zones <!zone!>",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          },
+          {
+            "command": "show route table inet.0",
+            "passRule": true,
+            "rules": [
+              {
+                "rule": "",
+                "eval": "contains",
+                "severity": "error"
+              }
+            ]
+          }
+        ],
+        "created": 1780367306548,
+        "createdBy": "6a0c557474e890f65883e175",
+        "lastUpdated": 1780368441729,
+        "lastUpdatedBy": "mike.elrom@itential.com"
       }
     }
   ],

--- a/Juniper/JUNOS/README.md
+++ b/Juniper/JUNOS/README.md
@@ -186,6 +186,15 @@ An IAG5 project for Juniper JUNOS device automation via NETCONF, organized into 
 - **Create & Update Inventory from NetBox** — creates or updates an Inventory Manager inventory using NetBox as the source of truth
 - **Clear & Delete Inventory** — removes all nodes from an inventory and deletes it
 
+**Port Turn Up**
+- **Port Turn Up** — provisions an 802.1Q sub-interface on a Juniper JUNOS device: fetches device details from inventory, runs a pre-check, backs up the running config, renders the sub-interface config via Jinja2, pushes it with `send-config`, and verifies with a post-check
+- Command templates: Port Turn Up Pre Check · Port Turn Up Post Check — capture `show configuration interfaces`, `show security zones`, and `show route table inet.0` before and after the change
+- Template: **802.1Q Sub Interface** — Jinja2 template generating `set`-format lines for the interface unit, VLAN ID, IP address, and security zone assignment
+- Form: **8021.Q Sub Interface Form** — inputs: device, interface, VLAN ID, description, IP address, zone
+
+> **Before running:** Ensure the target interface supports VLAN tagging and the security zone
+> already exists on the device. The form's `zone` field must match an existing zone name exactly.
+
 **Dependencies:** `junos-netconf-*` services registered in IAG5 (see Device Drivers above)
 
 ---


### PR DESCRIPTION
## Summary

- Merges 5 Port Turn Up components from platform export into `Juniper JUNOS.project.json`: workflow, 802.1Q Jinja2 template, form, and pre/post check command templates
- Adds **Port Turn Up** section to the Juniper JUNOS README documenting the workflow, inputs, templates, and a security zone prerequisite note

## Changes

| File | Change |
|------|--------|
| `Juniper/JUNOS/Projects/Juniper JUNOS.project.json` | Added iids 44–48 (Port Turn Up folder) |
| `Juniper/JUNOS/README.md` | New Port Turn Up section under Projects |

## Test plan

- [ ] Import updated project file into IAP — verify `/Port Turn Up` folder appears with all 5 assets
- [ ] Run Port Turn Up workflow against a lab device with a known interface/VLAN/zone
- [ ] Confirm pre-check captures interface config and route table; post-check reflects the new sub-interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)