### PR TITLE
Add Ruckus Fastiron netmiko-python IAG5 device driver

### DIFF
--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -1,0 +1,167 @@
+# fastiron-netmiko — IAG5 Python script service
+
+SSH CLI-based driver for Ruckus Fastiron (IronWare OS) switches. Uses
+[netmiko](https://github.com/ktbyers/netmiko) for SSH connectivity.
+
+Tested against Ruckus ICX series switches running FastIron OS (SPS 08.0.95r+).
+
+## Why a custom driver
+
+Fastiron devices are legacy switches that advertise `ssh-rsa` host keys and
+include `diffie-hellman-group14-sha1` / `diffie-hellman-group1-sha1` in their
+SSH KEX list. Both were removed from paramiko 5.0 (May 2026). This driver pins
+`paramiko<5` so those algorithms remain available, and passes
+`disabled_algorithms={"pubkeys": []}` to re-enable `ssh-rsa` host-key
+verification which paramiko 3.3+ disables by default.
+
+## Actions
+
+| Action | Purpose | Notes |
+|---|---|---|
+| `is-alive` | Verify SSH reachability | Runs `show version`; returns bare `true`/`false` |
+| `run-command` | Execute one or more CLI show/exec commands | `--command` is repeatable |
+| `get-config` | Retrieve running configuration | Full config or filtered by `--section` |
+| `send-command` | Apply config commands and save | Runs `send_config_set()` then `write memory` |
+| `set-config` | Config Manager broker entry point | Same as `send-command`; input is a CM changes array |
+
+## get-config section filter
+
+Pass a section string to retrieve a subset of the running config:
+
+```bash
+# Full running config (default)
+FASTIRON_OP=get-config python main.py --host 10.0.0.1 --user itential --password "$PASS"
+
+# Single interface
+FASTIRON_OP=get-config python main.py ... --section "interface ethernet 1/1/1"
+
+# All interfaces
+FASTIRON_OP=get-config python main.py ... --section "interface"
+
+# VLAN config
+FASTIRON_OP=get-config python main.py ... --section "vlan 100"
+```
+
+The `section` value is appended directly to `show running-config`, so any valid
+IronWare filter string works.
+
+## Invocation model
+
+One service per operation — each points at the same `main.py` and sets a
+different `FASTIRON_OP` environment variable. Connection parameters come from
+the device's Inventory Manager record (piped to stdin as `InventoryInfo` JSON
+by gateway5). CLI flags override stdin values for local testing.
+
+### Registered services
+
+| Service name | Operation |
+|---|---|
+| `fastiron-netmiko-is-alive` | is-alive |
+| `fastiron-netmiko-run-command` | run-command |
+| `fastiron-netmiko-get-config` | get-config |
+| `fastiron-netmiko-send-command` | send-command |
+| `fastiron-netmiko-set-config` | set-config (broker) |
+
+### From iagctl
+
+```bash
+iagctl run service python-script fastiron-netmiko-is-alive
+
+iagctl run service python-script fastiron-netmiko-run-command \
+  --set command="show version"
+
+iagctl run service python-script fastiron-netmiko-run-command \
+  --set command="show interfaces brief"
+
+iagctl run service python-script fastiron-netmiko-get-config
+
+iagctl run service python-script fastiron-netmiko-get-config \
+  --set section="interface ethernet 1/1/1"
+
+iagctl run service python-script fastiron-netmiko-send-command \
+  --set 'commands=["interface ethernet 1/1/1", "port-name uplink", "exit"]'
+```
+
+### From an Inventory Manager action mapping
+
+```json
+{
+  "name": "run-command",
+  "action_type": "iag5-service",
+  "action_config": {
+    "service_name": "fastiron-netmiko-run-command",
+    "cluster_id": "cluster-itential"
+  },
+  "action_parameters": {}
+}
+```
+
+### Direct local testing
+
+```bash
+FASTIRON_OP=is-alive python main.py \
+  --host 10.0.0.1 --user itential --password "$PASS"
+
+FASTIRON_OP=run-command python main.py \
+  --host 10.0.0.1 --user itential --password "$PASS" \
+  --command "show version"
+
+FASTIRON_OP=get-config python main.py \
+  --host 10.0.0.1 --user itential --password "$PASS" \
+  --section "interface ethernet 1/1/1"
+
+FASTIRON_OP=send-command python main.py \
+  --host 10.0.0.1 --user itential --password "$PASS" \
+  --command "interface ethernet 1/1/1" \
+  --command "port-name uplink" \
+  --command "exit"
+```
+
+## Inventory attributes
+
+Set these on the device record in Inventory Manager:
+
+```json
+{
+  "name": "fastiron-sw-01",
+  "attributes": {
+    "itential_host": "10.0.0.1",
+    "itential_user": "itential",
+    "itential_password": "$SECRET_vault $KEY_fastiron_pass",
+    "itential_driver_options": {
+      "netmiko": {
+        "port": 22,
+        "timeout": 30,
+        "device_type": "ruckus_fastiron",
+        "command_timeout": 60
+      }
+    }
+  }
+}
+```
+
+| Attribute | Default | Purpose |
+|---|---|---|
+| `itential_host` | — | Device management IP (required) |
+| `itential_user` | — | SSH username (required) |
+| `itential_password` | — | SSH password (required) |
+| `port` | `22` | SSH port |
+| `timeout` | `30` | SSH connection timeout (seconds) |
+| `device_type` | `ruckus_fastiron` | netmiko device type |
+| `command_timeout` | — | CLI read timeout for `run-command` (seconds); use for slow commands |
+
+> **Note:** Fastiron has user EXEC and privileged EXEC modes. If your devices are configured to auto-elevate to privileged mode on SSH login, no enable password is needed. If your devices require a separate enable password, add `"secret": "<enable-password>"` under `itential_driver_options.netmiko` and pass `--secret` when testing locally.
+
+## Prerequisites
+
+- TCP/22 reachable from IAG5 to the device
+- SSH enabled on the device (`ip ssh`)
+- Credentials with sufficient privilege for the required operations
+
+## Local development
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+FASTIRON_OP=is-alive python main.py --host 10.0.0.1 --user itential --password "$PASS"
+```

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -130,7 +130,8 @@ Set these on the device record in Inventory Manager:
     "itential_password": "$SECRET_vault $KEY_fastiron_pass",
     "itential_driver_options": {
       "netmiko": {
-        "device_type": "ruckus_fastiron"
+        "device_type": "ruckus_fastiron",
+        "disabled_algorithms": {"pubkeys": []}
       }
     }
   }
@@ -143,8 +144,9 @@ Set these on the device record in Inventory Manager:
 | `itential_user` | — | SSH username (required) |
 | `itential_password` | — | SSH password (required) |
 | `device_type` | `ruckus_fastiron` | netmiko device type |
+| `disabled_algorithms` | — | Re-enables `ssh-rsa` host keys disabled by default in newer paramiko versions. Required for Fastiron devices. Set to `{"pubkeys": []}` |
 
-> **Note:** Do not set `port`, `timeout`, or `command_timeout` inside `itential_driver_options.netmiko` — IAG5's internal `DriverOptions` schema rejects unrecognised fields. The driver uses sensible defaults (port 22, timeout 30s). Override connection params via CLI flags when testing locally instead.
+> **Note:** Only fields defined in netsdk's `DriverOptions` model are allowed inside `itential_driver_options.netmiko`. Do not add `port`, `timeout`, or other unrecognised fields — IAG5 will reject the inventory node with a pydantic validation error.
 
 > **Note:** Fastiron has user EXEC and privileged EXEC modes. If your devices are configured to auto-elevate to privileged mode on SSH login, no enable password is needed. If your devices require a separate enable password, add `"secret": "<enable-password>"` under `itential_driver_options.netmiko` and pass `--secret` when testing locally.
 

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -147,8 +147,7 @@ Set these on the device record in Inventory Manager:
     "itential_password": "$SECRET_vault $KEY_fastiron_pass",
     "itential_driver_options": {
       "netmiko": {
-        "device_type": "ruckus_fastiron",
-        "disabled_algorithms": {"pubkeys": []}
+        "device_type": "ruckus_fastiron"
       }
     }
   }

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -102,15 +102,53 @@ iagctl run service python-script fastiron-netmiko-send-command \
 ### From an Inventory Manager action mapping
 
 ```json
-{
-  "name": "run-command",
-  "action_type": "iag5-service",
-  "action_config": {
-    "service_name": "fastiron-netmiko-run-command",
-    "cluster_id": "cluster-itential"
+[
+  {
+    "name": "is-alive",
+    "action_type": "iag5-service",
+    "action_config": {
+      "service_name": "fastiron-netmiko-is-alive",
+      "cluster_id": "cluster-itential"
+    },
+    "action_parameters": {}
   },
-  "action_parameters": {}
-}
+  {
+    "name": "run-command",
+    "action_type": "iag5-service",
+    "action_config": {
+      "service_name": "fastiron-netmiko-run-command",
+      "cluster_id": "cluster-itential"
+    },
+    "action_parameters": {}
+  },
+  {
+    "name": "get-config",
+    "action_type": "iag5-service",
+    "action_config": {
+      "service_name": "fastiron-netmiko-get-config",
+      "cluster_id": "cluster-itential"
+    },
+    "action_parameters": {}
+  },
+  {
+    "name": "send-command",
+    "action_type": "iag5-service",
+    "action_config": {
+      "service_name": "fastiron-netmiko-send-command",
+      "cluster_id": "cluster-itential"
+    },
+    "action_parameters": {}
+  },
+  {
+    "name": "set-config",
+    "action_type": "iag5-service",
+    "action_config": {
+      "service_name": "fastiron-netmiko-set-config",
+      "cluster_id": "cluster-itential"
+    },
+    "action_parameters": {}
+  }
+]
 ```
 
 ### Direct local testing

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -130,10 +130,7 @@ Set these on the device record in Inventory Manager:
     "itential_password": "$SECRET_vault $KEY_fastiron_pass",
     "itential_driver_options": {
       "netmiko": {
-        "port": 22,
-        "timeout": 30,
-        "device_type": "ruckus_fastiron",
-        "command_timeout": 60
+        "device_type": "ruckus_fastiron"
       }
     }
   }
@@ -145,10 +142,9 @@ Set these on the device record in Inventory Manager:
 | `itential_host` | — | Device management IP (required) |
 | `itential_user` | — | SSH username (required) |
 | `itential_password` | — | SSH password (required) |
-| `port` | `22` | SSH port |
-| `timeout` | `30` | SSH connection timeout (seconds) |
 | `device_type` | `ruckus_fastiron` | netmiko device type |
-| `command_timeout` | — | CLI read timeout for `run-command` (seconds); use for slow commands |
+
+> **Note:** Do not set `port`, `timeout`, or `command_timeout` inside `itential_driver_options.netmiko` — IAG5's internal `DriverOptions` schema rejects unrecognised fields. The driver uses sensible defaults (port 22, timeout 30s). Override connection params via CLI flags when testing locally instead.
 
 > **Note:** Fastiron has user EXEC and privileged EXEC modes. If your devices are configured to auto-elevate to privileged mode on SSH login, no enable password is needed. If your devices require a separate enable password, add `"secret": "<enable-password>"` under `itential_driver_options.netmiko` and pass `--secret` when testing locally.
 

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/README.md
@@ -45,6 +45,23 @@ FASTIRON_OP=get-config python main.py ... --section "vlan 100"
 The `section` value is appended directly to `show running-config`, so any valid
 IronWare filter string works.
 
+## Known incompatible workflow tasks
+
+### `sendCommand` (GatewayManager)
+
+**Do not use** `GatewayManager.sendCommand` with this driver. That task routes through netsdk's built-in netmiko driver, which expects a structured `CommandResult` response with timing fields (`start_time`, `end_time`, `elapsed_time`). This driver returns plain text output and does not produce that format, resulting in:
+
+```
+"data": "failed to parse start_time for command 0: failed to parse timestamp string '':
+parsing time \"\" as \"2006-01-02 15:04:05\": cannot parse \"\" as \"2006\""
+```
+
+**Use instead:**
+- `GatewayManager.runService` — call the IAG5 service directly by name
+- `MOP.runCommandTemplate` — brokered device tasks such as MOP command templates
+
+---
+
 ## Invocation model
 
 One service per operation — each points at the same `main.py` and sets a

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
@@ -2,7 +2,7 @@
 repositories:
   - name: itential-assets
     description: Itential community assets repository
-    url: https://github.com/itential/assets.git
+    url: https://github.com/ZackStr/assets.git
     reference: devel
 
 decorators:

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
@@ -2,7 +2,7 @@
 repositories:
   - name: itential-assets
     description: Itential community assets repository
-    url: https://github.com/ZackStr/assets.git
+    url: https://github.com/itential/assets.git
     reference: devel
 
 decorators:

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/import.yaml
@@ -1,0 +1,118 @@
+---
+repositories:
+  - name: itential-assets
+    description: Itential community assets repository
+    url: https://github.com/itential/assets.git
+    reference: devel
+
+decorators:
+  - name: fastiron-netmiko-run-command-input
+    schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: fastiron-netmiko-run-command inputs
+      type: object
+      properties:
+        command:
+          description: CLI command to execute (e.g. "show version")
+          type: string
+      required: [command]
+      additionalProperties: false
+
+  - name: fastiron-netmiko-get-config-input
+    schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: fastiron-netmiko-get-config inputs
+      type: object
+      properties:
+        section:
+          description: >
+            Optional section to retrieve (e.g. "interface ethernet 1/1/1", "vlan 100").
+            Omit to retrieve the full running configuration.
+          type: string
+      additionalProperties: false
+
+  - name: fastiron-netmiko-send-command-input
+    schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: fastiron-netmiko-send-command inputs
+      type: object
+      properties:
+        commands:
+          description: Array of IronWare config commands to apply (e.g. ["interface ethernet 1/1/1", "port-name uplink"])
+          type: array
+          items:
+            type: string
+      required: [commands]
+      additionalProperties: false
+
+  - name: fastiron-netmiko-set-config-input
+    schema:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      title: fastiron-netmiko-set-config inputs
+      type: object
+      properties:
+        config:
+          description: JSON-encoded Config Manager changes array [{parents, old, new}]
+          type: string
+      required: [config]
+      additionalProperties: false
+
+services:
+  - name: fastiron-netmiko-is-alive
+    type: python-script
+    description: Ruckus Fastiron — verify SSH reachability via show version
+    repository: itential-assets
+    working-directory: Ruckus/Fastiron/device-drivers/netmiko-python
+    filename: main.py
+    runtime:
+      env:
+        FASTIRON_OP: is-alive
+    tags: [driver, fastiron, netmiko]
+
+  - name: fastiron-netmiko-run-command
+    type: python-script
+    description: Ruckus Fastiron — execute one or more CLI show/exec commands
+    repository: itential-assets
+    working-directory: Ruckus/Fastiron/device-drivers/netmiko-python
+    filename: main.py
+    decorator: fastiron-netmiko-run-command-input
+    runtime:
+      env:
+        FASTIRON_OP: run-command
+    tags: [driver, fastiron, netmiko]
+
+  - name: fastiron-netmiko-get-config
+    type: python-script
+    description: Ruckus Fastiron — retrieve running configuration (full or by section)
+    repository: itential-assets
+    working-directory: Ruckus/Fastiron/device-drivers/netmiko-python
+    filename: main.py
+    decorator: fastiron-netmiko-get-config-input
+    runtime:
+      env:
+        FASTIRON_OP: get-config
+    tags: [driver, fastiron, netmiko]
+
+  - name: fastiron-netmiko-send-command
+    type: python-script
+    description: Ruckus Fastiron — apply an array of config commands and save (write memory)
+    repository: itential-assets
+    working-directory: Ruckus/Fastiron/device-drivers/netmiko-python
+    filename: main.py
+    decorator: fastiron-netmiko-send-command-input
+    runtime:
+      env:
+        FASTIRON_OP: send-command
+    tags: [driver, fastiron, netmiko]
+
+  - name: fastiron-netmiko-set-config
+    type: python-script
+    description: Ruckus Fastiron — Config Manager remediation via IM iag5-service action (broker entry point)
+    repository: itential-assets
+    working-directory: Ruckus/Fastiron/device-drivers/netmiko-python
+    filename: main.py
+    decorator: fastiron-netmiko-set-config-input
+    runtime:
+      env:
+        FASTIRON_OP: set-config
+    tags: [driver, fastiron, netmiko, broker]

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -164,39 +164,10 @@ _DISPATCH = {
 
 
 def _read_stdin_inventory():
-    """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data.
-
-    IAG5 pipes InventoryInfo JSON to stdin via a Go I/O goroutine. Reading until
-    EOF is critical: if Python exits while IAG5's goroutine is still writing, Go's
-    cmd.Wait() receives a broken-pipe error (not an ExitError) and reports -255.
-    We read until EOF or a 5-second total timeout. When invoked without inventory
-    (direct iagctl test), stdin has no data and the 2-second initial select() times
-    out cleanly.
-    """
-    import select, os, time
+    """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data."""
     if sys.stdin.isatty():
         return None
-    fd = sys.stdin.fileno()
-    # Wait up to 2 seconds for the first byte
-    ready, _, _ = select.select([sys.stdin], [], [], 2.0)
-    if not ready:
-        return None
-    # Read until EOF or 5-second total timeout
-    deadline = time.monotonic() + 5.0
-    chunks = []
-    while time.monotonic() < deadline:
-        remaining = deadline - time.monotonic()
-        ready, _, _ = select.select([sys.stdin], [], [], min(remaining, 1.0))
-        if not ready:
-            break
-        try:
-            chunk = os.read(fd, 65536)
-        except OSError:
-            break
-        if not chunk:
-            break  # EOF
-        chunks.append(chunk)
-    raw = b"".join(chunks).decode("utf-8", errors="replace")
+    raw = sys.stdin.read()
     if not raw or not raw.strip():
         return None
     try:
@@ -452,28 +423,10 @@ def main() -> int:
     conn = _resolve_connection(args, node)
     result = _DISPATCH[args.op](conn, args)
     formatted = _format_for_humans(result, args.op)
-    print(formatted)
-    sys.stdout.flush()
+    print(formatted, end="" if args.op == "is-alive" else "\n")
     if not result.get("success"):
         print(formatted, file=sys.stderr)
-        sys.stderr.flush()
-    # Drain any remaining stdin so IAG5's stdin-copy goroutine finishes cleanly.
-    # Without this, Python closing stdin mid-write causes cmd.Wait() to return a
-    # non-ExitError in Go, which IAG5 maps to -255 and discards stdout.
-    _drain_stdin()
     return 0 if result.get("success") else 1
-
-
-def _drain_stdin():
-    import select, os
-    if sys.stdin.isatty():
-        return
-    try:
-        while select.select([sys.stdin], [], [], 0.2)[0]:
-            if not os.read(sys.stdin.fileno(), 65536):
-                break
-    except OSError:
-        pass
 
 
 if __name__ == "__main__":

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -38,6 +38,11 @@ def _connect(conn):
         conn_timeout=conn["timeout"],
         # ssh-rsa host keys are disabled by default in paramiko 3.3+; re-enable for legacy devices
         disabled_algorithms={"pubkeys": []},
+        # Reduce from netmiko's generous defaults (banner=15s, auth=20s) to cut session setup time
+        banner_timeout=10,
+        auth_timeout=10,
+        # Use timing-based detection for internal session steps (config mode entry/exit)
+        fast_cli=True,
     )
     if conn.get("secret"):
         kwargs["secret"] = conn["secret"]
@@ -204,7 +209,7 @@ def _resolve_connection(args, node):
     user        = pick(args.user,        "itential_user",     default=None)
     password    = pick(args.password,    "itential_password", default=None)
     port        = pick(args.port,        "port",              default=22)
-    timeout     = pick(args.timeout,     "timeout",           default=30)
+    timeout     = pick(args.timeout,     "timeout",           default=10)
     device_type = pick(args.device_type, "device_type",       default="ruckus_fastiron")
     secret      = pick(args.secret,      "secret",            default=None)
     command_timeout = pick(args.command_timeout, "command_timeout", default=None)

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -166,24 +166,27 @@ _DISPATCH = {
 def _read_stdin_inventory():
     """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data.
 
-    IAG5 pipes InventoryInfo JSON to stdin but may keep the pipe open after
-    writing — sys.stdin.read() would block indefinitely waiting for EOF.
-    Instead we read in chunks, stopping when no new data arrives within 0.5s.
-    When invoked without inventory (direct iagctl test), stdin has no data and
-    the initial 2-second select() times out cleanly.
+    IAG5 pipes InventoryInfo JSON to stdin via a Go I/O goroutine. Reading until
+    EOF is critical: if Python exits while IAG5's goroutine is still writing, Go's
+    cmd.Wait() receives a broken-pipe error (not an ExitError) and reports -255.
+    We read until EOF or a 5-second total timeout. When invoked without inventory
+    (direct iagctl test), stdin has no data and the 2-second initial select() times
+    out cleanly.
     """
-    import select, os
+    import select, os, time
     if sys.stdin.isatty():
         return None
     fd = sys.stdin.fileno()
-    chunks = []
     # Wait up to 2 seconds for the first byte
     ready, _, _ = select.select([sys.stdin], [], [], 2.0)
     if not ready:
         return None
-    # Read all available data; stop when nothing new arrives within 0.5s
-    while True:
-        ready, _, _ = select.select([sys.stdin], [], [], 0.5)
+    # Read until EOF or 5-second total timeout
+    deadline = time.monotonic() + 5.0
+    chunks = []
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        ready, _, _ = select.select([sys.stdin], [], [], min(remaining, 1.0))
         if not ready:
             break
         try:
@@ -191,7 +194,7 @@ def _read_stdin_inventory():
         except OSError:
             break
         if not chunk:
-            break
+            break  # EOF
         chunks.append(chunk)
     raw = b"".join(chunks).decode("utf-8", errors="replace")
     if not raw or not raw.strip():
@@ -454,7 +457,23 @@ def main() -> int:
     if not result.get("success"):
         print(formatted, file=sys.stderr)
         sys.stderr.flush()
+    # Drain any remaining stdin so IAG5's stdin-copy goroutine finishes cleanly.
+    # Without this, Python closing stdin mid-write causes cmd.Wait() to return a
+    # non-ExitError in Go, which IAG5 maps to -255 and discards stdout.
+    _drain_stdin()
     return 0 if result.get("success") else 1
+
+
+def _drain_stdin():
+    import select, os
+    if sys.stdin.isatty():
+        return
+    try:
+        while select.select([sys.stdin], [], [], 0.2)[0]:
+            if not os.read(sys.stdin.fileno(), 65536):
+                break
+    except OSError:
+        pass
 
 
 if __name__ == "__main__":

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -432,8 +432,10 @@ def main() -> int:
     result = _DISPATCH[args.op](conn, args)
     formatted = _format_for_humans(result, args.op)
     print(formatted, end="" if args.op == "is-alive" else "\n")
+    sys.stdout.flush()
     if not result.get("success"):
         print(formatted, file=sys.stderr)
+        sys.stderr.flush()
     return 0 if result.get("success") else 1
 
 

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -424,12 +424,16 @@ def _format_for_humans(result, op):
 
 def main() -> int:
     # temporary debug — remove before contributing to itential/assets
-    try:
-        with open("/tmp/fastiron_debug.json", "w") as _f:
-            json.dump({"started": True, "argv": sys.argv,
-                       "FASTIRON_OP": os.environ.get("FASTIRON_OP")}, _f, indent=2)
-    except Exception:
-        pass
+    for _debug_path in ["/tmp/fastiron_debug.json", "/var/lib/gateway/fastiron_debug.json",
+                        "/var/tmp/fastiron_debug.json"]:
+        try:
+            with open(_debug_path, "w") as _f:
+                json.dump({"started": True, "argv": sys.argv,
+                           "FASTIRON_OP": os.environ.get("FASTIRON_OP"),
+                           "uid": os.getuid(), "cwd": os.getcwd()}, _f, indent=2)
+            break
+        except Exception:
+            pass
 
     args = build_parser().parse_args()
     if not args.op:

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -423,6 +423,14 @@ def _format_for_humans(result, op):
 
 
 def main() -> int:
+    # temporary debug — remove before contributing to itential/assets
+    try:
+        with open("/tmp/fastiron_debug.json", "w") as _f:
+            json.dump({"started": True, "argv": sys.argv,
+                       "FASTIRON_OP": os.environ.get("FASTIRON_OP")}, _f, indent=2)
+    except Exception:
+        pass
+
     args = build_parser().parse_args()
     if not args.op:
         raise SystemExit("--op flag or FASTIRON_OP env var must be set")
@@ -436,13 +444,6 @@ def main() -> int:
     if not result.get("success"):
         print(formatted, file=sys.stderr)
         sys.stderr.flush()
-    # temporary debug — remove before contributing to itential/assets
-    try:
-        with open("/tmp/fastiron_debug.json", "w") as _f:
-            json.dump({"op": args.op, "result": result, "formatted": formatted,
-                       "exit_code": 0 if result.get("success") else 1}, _f, indent=2, default=str)
-    except Exception:
-        pass
     return 0 if result.get("success") else 1
 
 

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -443,7 +443,7 @@ def main() -> int:
     conn = _resolve_connection(args, node)
     result = _DISPATCH[args.op](conn, args)
     formatted = _format_for_humans(result, args.op)
-    print(formatted, end="" if args.op == "is-alive" else "\n")
+    print(formatted)
     sys.stdout.flush()
     if not result.get("success"):
         print(formatted, file=sys.stderr)

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -166,16 +166,34 @@ _DISPATCH = {
 def _read_stdin_inventory():
     """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data.
 
-    When invoked directly via iagctl (no inventory node), stdin is an open pipe
-    with no data and no EOF — select() prevents blocking indefinitely.
+    IAG5 pipes InventoryInfo JSON to stdin but may keep the pipe open after
+    writing — sys.stdin.read() would block indefinitely waiting for EOF.
+    Instead we read in chunks, stopping when no new data arrives within 0.5s.
+    When invoked without inventory (direct iagctl test), stdin has no data and
+    the initial 2-second select() times out cleanly.
     """
-    import select
+    import select, os
     if sys.stdin.isatty():
         return None
+    fd = sys.stdin.fileno()
+    chunks = []
+    # Wait up to 2 seconds for the first byte
     ready, _, _ = select.select([sys.stdin], [], [], 2.0)
     if not ready:
         return None
-    raw = sys.stdin.read()
+    # Read all available data; stop when nothing new arrives within 0.5s
+    while True:
+        ready, _, _ = select.select([sys.stdin], [], [], 0.5)
+        if not ready:
+            break
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    raw = b"".join(chunks).decode("utf-8", errors="replace")
     if not raw or not raw.strip():
         return None
     try:

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Ruckus Fastiron netmiko service for IAG5.
+
+SSH CLI-based driver for Ruckus Fastiron (IronWare OS) switches.
+Uses netmiko for SSH with paramiko<5 to retain support for ssh-rsa host keys
+and legacy KEX algorithms advertised by these devices.
+
+Actions: is-alive, run-command, get-config, send-command, set-config
+
+Connection parameters (host, port, user, password, timeout, device_type) are
+read from stdin as JSON in the gateway5 InventoryInfo format:
+
+    {"inventory_nodes": [{"name": "...", "attributes": {
+        "itential_host": "...", "itential_user": "...",
+        "itential_password": "...",
+        "itential_driver_options": {"netmiko": {"port": 22, "timeout": 30, ...}}
+    }}]}
+
+CLI flags for connection params override stdin values — useful for local testing.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from netmiko import ConnectHandler
+from netmiko.exceptions import NetmikoAuthenticationException, NetmikoTimeoutException
+
+
+def _connect(conn):
+    kwargs = dict(
+        device_type=conn["device_type"],
+        host=conn["host"],
+        port=conn["port"],
+        username=conn["user"],
+        password=conn["password"],
+        conn_timeout=conn["timeout"],
+        # ssh-rsa host keys are disabled by default in paramiko 3.3+; re-enable for legacy devices
+        disabled_algorithms={"pubkeys": []},
+    )
+    if conn.get("secret"):
+        kwargs["secret"] = conn["secret"]
+    return ConnectHandler(**kwargs)
+
+
+def is_alive(conn, args) -> dict:
+    device_name = conn.get("device_name") or conn["host"]
+    try:
+        with _connect(conn) as net:
+            output = net.send_command("show version")
+        return {
+            "success": True,
+            "alive": True,
+            "host": conn["host"],
+            "device_name": device_name,
+            "output": output,
+        }
+    except (NetmikoAuthenticationException, NetmikoTimeoutException) as e:
+        return {
+            "success": False,
+            "alive": False,
+            "host": conn["host"],
+            "device_name": device_name,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "alive": False,
+            "host": conn["host"],
+            "device_name": device_name,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+
+
+def run_command(conn, args) -> dict:
+    if not args.command:
+        return {"success": False, "host": conn["host"], "error": "command is required for action=run-command"}
+    results = []
+    send_kwargs = {}
+    if conn.get("command_timeout") is not None:
+        send_kwargs["read_timeout"] = conn["command_timeout"]
+    try:
+        with _connect(conn) as net:
+            for cmd in args.command:
+                try:
+                    output = net.send_command(cmd, **send_kwargs)
+                    results.append({"command": cmd, "output": output, "success": True})
+                except Exception as e:
+                    results.append({"command": cmd, "output": str(e), "success": False})
+        return {"success": all(r["success"] for r in results), "host": conn["host"], "results": results}
+    except Exception as e:
+        return {
+            "success": False,
+            "host": conn["host"],
+            "error": str(e),
+            "error_type": type(e).__name__,
+            "results": results,
+        }
+
+
+def get_config(conn, args) -> dict:
+    cmd = "show running-config"
+    if args.section:
+        cmd = f"show running-config {args.section.strip()}"
+    try:
+        with _connect(conn) as net:
+            output = net.send_command(cmd)
+        return {
+            "success": True,
+            "host": conn["host"],
+            "section": args.section or None,
+            "config": output,
+        }
+    except Exception as e:
+        return {"success": False, "host": conn["host"], "error": str(e), "error_type": type(e).__name__}
+
+
+def send_command(conn, args) -> dict:
+    device_name = conn.get("device_name") or conn["host"]
+    if not args.command:
+        return {
+            "success": False,
+            "host": conn["host"],
+            "device_name": device_name,
+            "error": "command is required for action=send-command",
+        }
+    try:
+        with _connect(conn) as net:
+            config_output = net.send_config_set(args.command)
+            save_output = net.send_command("write memory")
+        result = {
+            "success": True,
+            "host": conn["host"],
+            "device_name": device_name,
+            "commands": args.command,
+            "output": config_output,
+            "save_output": save_output,
+        }
+        if hasattr(args, "_changes_list"):
+            result["_changes_list"] = args._changes_list
+        return result
+    except Exception as e:
+        return {
+            "success": False,
+            "host": conn["host"],
+            "device_name": device_name,
+            "commands": args.command,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+
+
+_DISPATCH = {
+    "is-alive":    is_alive,
+    "run-command": run_command,
+    "get-config":  get_config,
+    "send-command": send_command,
+    "set-config":  send_command,  # Config Manager broker alias — same logic, distinct output envelope
+}
+
+
+def _read_stdin_inventory():
+    """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data."""
+    if sys.stdin.isatty():
+        return None
+    raw = sys.stdin.read()
+    if not raw or not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or "inventory_nodes" not in data:
+        return None
+    nodes = data.get("inventory_nodes") or []
+    if not nodes:
+        return None
+    return nodes[0]
+
+
+def _resolve_connection(args, node):
+    """Merge connection params: CLI args win over inventory attributes."""
+    attrs = (node or {}).get("attributes", {}) or {}
+    netmiko_opts = (attrs.get("itential_driver_options") or {}).get("netmiko") or {}
+
+    def pick(cli_val, *attr_keys, default=None):
+        if cli_val is not None:
+            return cli_val
+        for key in attr_keys:
+            val = netmiko_opts.get(key)
+            if val is not None:
+                return val
+        for key in attr_keys:
+            val = attrs.get(key)
+            if val is not None:
+                return val
+        return default
+
+    host        = pick(args.host,        "itential_host",     default=None)
+    user        = pick(args.user,        "itential_user",     default=None)
+    password    = pick(args.password,    "itential_password", default=None)
+    port        = pick(args.port,        "port",              default=22)
+    timeout     = pick(args.timeout,     "timeout",           default=30)
+    device_type = pick(args.device_type, "device_type",       default="ruckus_fastiron")
+    secret      = pick(args.secret,      "secret",            default=None)
+    command_timeout = pick(args.command_timeout, "command_timeout", default=None)
+
+    missing = [name for name, val in [("host", host), ("user", user), ("password", password)] if not val]
+    if missing:
+        raise SystemExit(
+            f"missing required connection field(s): {', '.join(missing)} "
+            f"(provide via --{missing[0]} or inventory attribute itential_{missing[0]})"
+        )
+
+    return {
+        "host":            host,
+        "port":            int(port),
+        "user":            user,
+        "password":        password,
+        "timeout":         int(timeout),
+        "device_type":     str(device_type),
+        "secret":          secret or None,
+        "command_timeout": int(command_timeout) if command_timeout is not None else None,
+        "device_name":     (node or {}).get("name") or host,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ruckus Fastiron netmiko operations for IAG5")
+    parser.add_argument("--op", default=os.environ.get("FASTIRON_OP"),
+                        choices=list(_DISPATCH),
+                        help="Operation to perform. Defaults to FASTIRON_OP env var.")
+
+    # Connection params
+    parser.add_argument("--host",         default=None, help="Override the inventory's itential_host")
+    parser.add_argument("--port",         default=None, help="Override SSH port (default 22)")
+    parser.add_argument("--user",         default=None, help="Override the inventory's itential_user")
+    parser.add_argument("--password",     default=None, help="Override the inventory's itential_password")
+    parser.add_argument("--secret",       default=None, help="Enable password (privileged EXEC)")
+    parser.add_argument("--timeout",      default=None, help="Override SSH connection timeout (default 30s)")
+    parser.add_argument("--command-timeout", dest="command_timeout", default=None,
+                        help="Override CLI read timeout for run-command (use for slow commands)")
+    parser.add_argument("--device-type",  dest="device_type", default=None,
+                        help="netmiko device type (default: ruckus_fastiron)")
+
+    # Operation params
+    parser.add_argument("--command",  action="append", default=None,
+                        help="CLI command (repeatable; multi-line values are split into separate commands)")
+    parser.add_argument("--commands", default=None,
+                        help="JSON array of config commands for send-command workflow task")
+    parser.add_argument("--config",   default=None,
+                        help="Config block or JSON-encoded Config Manager changes array")
+    parser.add_argument("--config_content", "--config-content", dest="config_content", default=None,
+                        help="Config block (Config Manager remediation path)")
+    parser.add_argument("--changes",  default=None,
+                        help="Config Manager changes array (JSON string) — extracts non-null 'new' values as config lines")
+    parser.add_argument("--options",  default=None,
+                        help="Config Manager remediation options JSON (currently unused)")
+    parser.add_argument("--section",  default=None,
+                        help="Optional section for get-config (e.g. 'interface ethernet 1/1/1', 'vlan 100')")
+
+    return parser
+
+
+def _normalize_args(args):
+    """Normalise empty-string CLI args injected by the IM/MOP framework to None.
+    Also folds --commands (JSON array), --config, --config_content, and --changes
+    into args.command for the send-command/set-config handlers."""
+    for attr in ("host", "user", "password", "secret", "device_type",
+                 "port", "timeout", "command_timeout",
+                 "config", "config_content", "commands", "changes", "options", "section"):
+        if getattr(args, attr, None) == "":
+            setattr(args, attr, None)
+
+    # send-command workflow task: --commands='["interface eth 1/1/1", "port-name uplink"]'
+    if args.commands and not args.command:
+        raw = args.commands
+        try:
+            cmds = json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(cmds, list):
+                args.command = [str(c) for c in cmds if str(c).strip()]
+            else:
+                args.command = [str(cmds)] if str(cmds).strip() else None
+        except (json.JSONDecodeError, TypeError):
+            args.command = [raw] if raw.strip() else None
+    args.commands = None
+
+    # broker paths pass --config; detect if it is a CM changes array or a plain config block
+    if args.config and not args.command:
+        config_val = args.config.strip()
+        if config_val.startswith("["):
+            try:
+                changes_list = json.loads(config_val)
+                lines = _extract_commands_from_changes(changes_list)
+                if lines:
+                    args.command = lines
+                    args._changes_list = changes_list
+            except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+                args.command = [args.config]
+        else:
+            args.command = [args.config]
+    args.config = None
+
+    if args.config_content and not args.command:
+        args.command = [args.config_content]
+    args.config_content = None
+
+    # Config Manager broker path: --changes '[{"parents":[],"old":...,"new":"..."}]'
+    if args.changes and not args.command:
+        raw = args.changes
+        try:
+            changes_list = json.loads(raw) if isinstance(raw, str) else raw
+            lines = _extract_commands_from_changes(changes_list)
+            if lines:
+                args.command = lines
+                args._changes_list = changes_list
+        except (json.JSONDecodeError, TypeError, KeyError, AttributeError):
+            pass
+    args.changes = None
+
+    # Split multi-line --command values into separate commands
+    if args.command:
+        split = []
+        for raw in args.command:
+            if raw is None:
+                continue
+            for line in raw.splitlines():
+                line = line.strip()
+                if line:
+                    split.append(line)
+        args.command = split or None
+
+
+def _extract_commands_from_changes(changes_list):
+    """Extract device config lines from a Config Manager changes array."""
+    lines = []
+    for c in changes_list:
+        new_val = str(c.get("new", "") or "").strip()
+        old_val = str(c.get("old", "") or "").strip()
+        if new_val:
+            lines.append(new_val)
+        elif old_val:
+            # Deletion: prefix with 'no' for IronWare CLI style
+            if old_val.startswith("no "):
+                lines.append(old_val)
+            else:
+                lines.append(f"no {old_val}")
+    return lines
+
+
+def _format_for_humans(result, op):
+    """Format output per operation.
+
+    is-alive:    bare 'true'/'false' — gw-manager parses stdout literally for device state.
+    run-command: plain text — IAP UI and MOP templates expect real newlines, not JSON.
+    get-config:  plain text config.
+    set-config:  JSON array of {result, parents, old, new} — Config Manager contract.
+    send-command: JSON envelope.
+    """
+    if op == "is-alive":
+        return "true" if result.get("alive", False) else "false"
+
+    if op == "run-command":
+        results = result.get("results") or []
+        if not results:
+            return f"ERROR: {result.get('error', 'connection failed')}"
+        if len(results) == 1:
+            r = results[0]
+            text = r.get("output", "")
+            if not r.get("success"):
+                text = f"ERROR: {r.get('error', 'unknown error')}\n{text}".rstrip()
+            return text
+        parts = []
+        for r in results:
+            parts.append(f"=== {r['command']} ===")
+            if not r.get("success"):
+                parts.append(f"ERROR: {r.get('error', 'unknown error')}")
+            if r.get("output"):
+                parts.append(r["output"])
+        return "\n".join(parts)
+
+    if op == "get-config":
+        if not result.get("success"):
+            return f"ERROR: {result.get('error', 'config retrieval failed')}"
+        return result.get("config", "")
+
+    if op == "set-config":
+        if result.get("success"):
+            changes_list = result.get("_changes_list")
+            if changes_list:
+                output = [
+                    {
+                        "result": True,
+                        "parents": c.get("parents", []),
+                        "old": c.get("old", ""),
+                        "new": c.get("new", ""),
+                    }
+                    for c in changes_list
+                ]
+            else:
+                output = [
+                    {"result": True, "parents": [], "old": "", "new": cmd}
+                    for cmd in (result.get("commands") or [])
+                ]
+            return json.dumps(output)
+        else:
+            print(result.get("error", "Configuration failed"), file=sys.stderr)
+            return "[]"
+
+    return json.dumps(result, indent=2, default=str)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not args.op:
+        raise SystemExit("--op flag or FASTIRON_OP env var must be set")
+    _normalize_args(args)
+    node = _read_stdin_inventory()
+    conn = _resolve_connection(args, node)
+    result = _DISPATCH[args.op](conn, args)
+    formatted = _format_for_humans(result, args.op)
+    print(formatted, end="" if args.op == "is-alive" else "\n")
+    if not result.get("success"):
+        print(formatted, file=sys.stderr)
+    return 0 if result.get("success") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -242,9 +242,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--password",     default=None, help="Override the inventory's itential_password")
     parser.add_argument("--secret",       default=None, help="Enable password (privileged EXEC)")
     parser.add_argument("--timeout",      default=None, help="Override SSH connection timeout (default 30s)")
-    parser.add_argument("--command-timeout", dest="command_timeout", default=None,
+    parser.add_argument("--command-timeout", "--command_timeout", dest="command_timeout", default=None,
                         help="Override CLI read timeout for run-command (use for slow commands)")
-    parser.add_argument("--device-type",  dest="device_type", default=None,
+    parser.add_argument("--device-type", "--device_type", dest="device_type", default=None,
                         help="netmiko device type (default: ruckus_fastiron)")
 
     # Operation params

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -423,18 +423,6 @@ def _format_for_humans(result, op):
 
 
 def main() -> int:
-    # temporary debug — remove before contributing to itential/assets
-    for _debug_path in ["/tmp/fastiron_debug.json", "/var/lib/gateway/fastiron_debug.json",
-                        "/var/tmp/fastiron_debug.json"]:
-        try:
-            with open(_debug_path, "w") as _f:
-                json.dump({"started": True, "argv": sys.argv,
-                           "FASTIRON_OP": os.environ.get("FASTIRON_OP"),
-                           "uid": os.getuid(), "cwd": os.getcwd()}, _f, indent=2)
-            break
-        except Exception:
-            pass
-
     args = build_parser().parse_args()
     if not args.op:
         raise SystemExit("--op flag or FASTIRON_OP env var must be set")

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -436,6 +436,13 @@ def main() -> int:
     if not result.get("success"):
         print(formatted, file=sys.stderr)
         sys.stderr.flush()
+    # temporary debug — remove before contributing to itential/assets
+    try:
+        with open("/tmp/fastiron_debug.json", "w") as _f:
+            json.dump({"op": args.op, "result": result, "formatted": formatted,
+                       "exit_code": 0 if result.get("success") else 1}, _f, indent=2, default=str)
+    except Exception:
+        pass
     return 0 if result.get("success") else 1
 
 

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/main.py
@@ -164,8 +164,16 @@ _DISPATCH = {
 
 
 def _read_stdin_inventory():
-    """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data."""
+    """Read the InventoryInfo JSON gateway5 pipes to stdin. Returns None if no data.
+
+    When invoked directly via iagctl (no inventory node), stdin is an open pipe
+    with no data and no EOF — select() prevents blocking indefinitely.
+    """
+    import select
     if sys.stdin.isatty():
+        return None
+    ready, _, _ = select.select([sys.stdin], [], [], 2.0)
+    if not ready:
         return None
     raw = sys.stdin.read()
     if not raw or not raw.strip():

--- a/Ruckus/Fastiron/device-drivers/netmiko-python/requirements.txt
+++ b/Ruckus/Fastiron/device-drivers/netmiko-python/requirements.txt
@@ -1,0 +1,2 @@
+netmiko>=4.0,<5
+paramiko<5


### PR DESCRIPTION
## Summary

- Adds a new SSH CLI driver for **Ruckus ICX Fastiron** switches (IronWare OS) using netmiko
- Implements `is-alive`, `run-command`, `get-config`, `send-command`, and `set-config` (Config Manager broker) operations
- Pins `paramiko<5` to retain `ssh-rsa` host key and legacy KEX algorithm support removed in paramiko 5.0
- Validated on **ICX7250-48P**, FastIron SPS 08.0.95r

## Why a custom driver

Fastiron devices advertise `ssh-rsa` host keys which are disabled by default in newer paramiko versions. This driver pins `paramiko<5` and passes `disabled_algorithms={"pubkeys": []}` to re-enable `ssh-rsa` at the netmiko layer.

## Inventory node attributes

```json
{
  "itential_host": "<device-ip>",
  "itential_user": "<username>",
  "itential_password": "<password>",
  "itential_driver_options": {
    "netmiko": {
      "device_type": "ruckus_fastiron"
    }
  }
}
```

## Known incompatibility

`GatewayManager.sendCommand` does not work with this driver — use `GatewayManager.runService` or brokered MOP tasks instead. See README for details.

## Test plan

- [x] `is-alive` — verified via iagctl and IAP inventory action
- [x] `run-command` — `show version`, `show interfaces brief`
- [x] `get-config` — full running config and section filter
- [x] `send-command` — interface config push + `write memory` confirmed on ICX7250-48P
- [x] `set-config` — Config Manager broker flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)