### PR TITLE
Update Juniper JUNOS project from platform export

### DIFF
--- a/Juniper/JUNOS/Projects/Juniper JUNOS.project.json
+++ b/Juniper/JUNOS/Projects/Juniper JUNOS.project.json
@@ -1,21 +1,21 @@
 {
-  "_id": "6a1de7f998f25fd9d4056c91",
+  "_id": "6a138e0000000000ffff0001",
   "name": "Juniper JUNOS",
   "description": "Juniper JUNOS inventory using NETCONF, software upgrade, and golden configuration",
   "components": [
     {
       "iid": 22,
-      "reference": "6a1de7f998f25fd9d4056c92",
+      "reference": "6a13848a75bc43e3a0bf3492",
       "type": "jsonForm",
       "folder": "/Software Upgrade",
       "document": {
-        "id": "6a1de7f998f25fd9d4056c92",
+        "id": "6a13848a75bc43e3a0bf3492",
         "created": "2026-05-24T23:06:50.250Z",
         "createdBy": "mike.elrom@itential.com",
-        "lastUpdated": "2026-06-02T03:09:03.262Z",
+        "lastUpdated": "2026-06-25T09:21:14.878Z",
         "lastUpdatedBy": "mike.elrom@itential.com",
         "name": "Upgrade Form",
-        "description": "Form input for the  Juniper software upgrade automation.",
+        "description": "Form input for the Juniper software upgrade automation.",
         "struct": {
           "type": "array",
           "items": [
@@ -23,10 +23,10 @@
               "nodeId": "fp-juno-001",
               "type": "string",
               "title": "Device",
-              "description": "Inventory device name (e.g. 'aws-lab-junos')",
-              "placeholder": "aws-lab-junos",
+              "description": "Inventory device name (e.g. 'Itential Lab JUNOS::aws-lab-junos')",
+              "placeholder": "Itential Lab JUNOS::aws-lab-junos",
               "required": true,
-              "default": "aws-lab-junos",
+              "default": "Itential Lab JUNOS::aws-lab-junos",
               "customKey": "device"
             },
             {
@@ -117,7 +117,7 @@
         },
         "schema": {
           "title": "Upgrade Form",
-          "description": "Form input for the Juniper software upgrade automation. Captures device, target version, image staging details, and run options (dry-run, change ref).",
+          "description": "Form input for the Juniper software upgrade automation.",
           "type": "object",
           "required": [
             "device",
@@ -130,8 +130,8 @@
               "type": "string",
               "title": "Device",
               "_id": "/properties/device",
-              "description": "Inventory device name (e.g. 'aws-lab-junos')",
-              "default": "aws-lab-junos"
+              "description": "Inventory device name (e.g. 'Itential Lab JUNOS::aws-lab-junos')",
+              "default": "Itential Lab JUNOS::aws-lab-junos"
             },
             "target_version": {
               "type": "string",
@@ -174,7 +174,7 @@
         },
         "uiSchema": {
           "device": {
-            "ui:placeholder": "aws-lab-junos"
+            "ui:placeholder": "Itential Lab JUNOS::aws-lab-junos"
           },
           "target_version": {
             "ui:placeholder": "22.4R2.8"
@@ -200,14 +200,14 @@
     },
     {
       "iid": 42,
-      "reference": "6a1de7f998f25fd9d4056c93",
+      "reference": "6a1de30f62b073861f971611",
       "type": "jsonForm",
       "folder": "/Golden Configuration",
       "document": {
-        "id": "6a1de7f998f25fd9d4056c93",
+        "id": "6a1de30f62b073861f971611",
         "created": "2026-06-01T19:52:47.654Z",
         "createdBy": "mike.elrom@itential.com",
-        "lastUpdated": "2026-06-02T03:09:03.262Z",
+        "lastUpdated": "2026-06-24T20:03:06.833Z",
         "lastUpdatedBy": "mike.elrom@itential.com",
         "name": "Compliance Form",
         "description": "",
@@ -329,14 +329,14 @@
     },
     {
       "iid": 46,
-      "reference": "6a1e494f62b073861f971613",
+      "reference": "6a1e325462b073861f971612",
       "type": "jsonForm",
       "folder": "/Port Turn Up",
       "document": {
-        "id": "6a1e494f62b073861f971613",
+        "id": "6a1e325462b073861f971612",
         "created": "2026-06-02T01:31:00.689Z",
         "createdBy": "mike.elrom@itential.com",
-        "lastUpdated": "2026-06-02T03:09:03.262Z",
+        "lastUpdated": "2026-06-25T09:10:42.623Z",
         "lastUpdatedBy": "mike.elrom@itential.com",
         "name": "8021.Q Sub Interface Form",
         "description": "",
@@ -354,7 +354,7 @@
               "binding": false,
               "rel": "item",
               "targetPointer": "/default",
-              "default": "aws-lab-junos"
+              "default": "Itential Lab JUNOS::aws-lab-junos"
             },
             {
               "nodeId": "152dff76-28ec-4162-8dca-338dd7e17bb1",
@@ -443,7 +443,7 @@
               "title": "Device",
               "_id": "/properties/device",
               "description": "",
-              "default": "aws-lab-junos"
+              "default": "Itential Lab JUNOS::aws-lab-junos"
             },
             "interface": {
               "type": "string",
@@ -519,7 +519,7 @@
     },
     {
       "iid": 48,
-      "reference": "@6a1de7f998f25fd9d4056c91: Port Turn Up Post Check",
+      "reference": "@6a138e0000000000ffff0001: Port Turn Up Post Check",
       "type": "mopCommandTemplate",
       "folder": "/Port Turn Up",
       "document": {
@@ -566,13 +566,13 @@
         ],
         "created": 1780367306548,
         "createdBy": "6a0c557474e890f65883e175",
-        "lastUpdated": 1780369743332,
+        "lastUpdated": 1782331386951,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 47,
-      "reference": "@6a1de7f998f25fd9d4056c91: Port Turn Up Pre Check",
+      "reference": "@6a138e0000000000ffff0001: Port Turn Up Pre Check",
       "type": "mopCommandTemplate",
       "folder": "/Port Turn Up",
       "document": {
@@ -619,13 +619,13 @@
         ],
         "created": 1780364670141,
         "createdBy": "6a0c557474e890f65883e175",
-        "lastUpdated": 1780369743445,
+        "lastUpdated": 1782331387307,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 31,
-      "reference": "@6a1de7f998f25fd9d4056c91: Pre and Post Checks",
+      "reference": "@6a138e0000000000ffff0001: Pre and Post Checks",
       "type": "mopCommandTemplate",
       "folder": "/Software Upgrade",
       "document": {
@@ -683,13 +683,13 @@
         ],
         "created": 1779675515376,
         "createdBy": "itential-02",
-        "lastUpdated": 1780369743636,
+        "lastUpdated": 1782331387033,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 36,
-      "reference": "@6a1de7f998f25fd9d4056c91: Reboot",
+      "reference": "@6a138e0000000000ffff0001: Reboot",
       "type": "mopCommandTemplate",
       "folder": "/Software Upgrade",
       "document": {
@@ -714,13 +714,13 @@
         ],
         "created": 1779719937714,
         "createdBy": "6a0c557474e890f65883e175",
-        "lastUpdated": 1780369743544,
+        "lastUpdated": 1782331387198,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 32,
-      "reference": "@6a1de7f998f25fd9d4056c91: Stage Upgrade",
+      "reference": "@6a138e0000000000ffff0001: Stage Upgrade",
       "type": "mopCommandTemplate",
       "folder": "/Software Upgrade",
       "document": {
@@ -745,13 +745,13 @@
         ],
         "created": 1779675515780,
         "createdBy": "itential-02",
-        "lastUpdated": 1780369743744,
+        "lastUpdated": 1782331387095,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 27,
-      "reference": "@6a1de7f998f25fd9d4056c91: Verify Image",
+      "reference": "@6a138e0000000000ffff0001: Verify Image",
       "type": "mopCommandTemplate",
       "folder": "/Software Upgrade",
       "document": {
@@ -787,13 +787,13 @@
         ],
         "created": 1779674845008,
         "createdBy": "itential-02",
-        "lastUpdated": 1780369743712,
+        "lastUpdated": 1782331387155,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 30,
-      "reference": "@6a1de7f998f25fd9d4056c91: Version Check",
+      "reference": "@6a138e0000000000ffff0001: Version Check",
       "type": "mopCommandTemplate",
       "folder": "/Software Upgrade",
       "document": {
@@ -825,18 +825,18 @@
         ],
         "created": 1779674846087,
         "createdBy": "itential-02",
-        "lastUpdated": 1780369743602,
+        "lastUpdated": 1782331387264,
         "lastUpdatedBy": "mike.elrom@itential.com"
       }
     },
     {
       "iid": 33,
-      "reference": "ccebebcc-0955-4202-8fda-32d4845e4a12",
+      "reference": "d7825e52-44a8-4aaf-a485-341981d34e01",
       "type": "workflow",
       "folder": "/Software Upgrade",
       "document": {
         "name": "JUNOS Upgrade",
-        "description": "make sure when this is called that the input is an object called formData. That formData object will have the following as it's JSON object {\n  \"device\": \"aws-lab-junos\",\n  \"target_version\": \"22.4R2.8\",\n  \"image_path\": \"/var/tmp/junos-install-vsrx3-x86-64-22.4R2.8.tgz\",\n  \"image_sha256\": \"8d486921598bb89afd3ab54dcf8fa7cb80423c3977ddaa86dd15e84f13d465b2\"\n}",
+        "description": "Sample Input\n  {\n  \"device\": \"Itential Lab JUNOS::aws-lab-junos\",\n  \"target_version\": \"22.4R2.8\",\n  \"image_path\": \"/var/tmp/junos-install-vsrx3-x86-64-22.4R2.8.tgz\",\n  \"image_sha256\": \"8d486921598bb89afd3ab54dcf8fa7cb80423c3977ddaa86dd15e84f13d465b2\"\n}",
         "tasks": {
           "1784": {
             "name": "runCode",
@@ -854,7 +854,7 @@
                 "language": "python",
                 "code": "import sys\nimport json\nimport re\n\n# \u2500\u2500 Read inputs from stdin (IAG runCode standard) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\ndata = json.load(sys.stdin)\n\ndevice_results = data.get('device_results', {})\ntarget_version  = data.get('target_version', '')\n\n# \u2500\u2500 Extract device name and version from 'show version' output \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\ncommands    = device_results.get('commands_results', [])\ndevice_name = commands[0].get('device') if commands else None\n\nfound_version = None\nfor cmd in commands:\n    if cmd.get('raw', '').strip().lower() == 'show version':\n        response = cmd.get('response', '')\n        match = re.search(r'^Junos:\\s+(\\S+)', response, re.MULTILINE)\n        if match:\n            found_version = match.group(1)\n        break\n\n# \u2500\u2500 Build result \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nif found_version is None:\n    result = {\n        'passed':  False,\n        'found':   None,\n        'target':  target_version,\n        'device':  device_name,\n        'message': \"Could not extract Junos version \u2014 'show version' output missing or malformed.\"\n    }\nelse:\n    passed = found_version == target_version\n    result = {\n        'passed':  passed,\n        'found':   found_version,\n        'target':  target_version,\n        'device':  device_name,\n        'message': (\n            f\"Device '{device_name}' is running Junos {found_version} \u2014 matches target {target_version}.\"\n            if passed else\n            f\"Device '{device_name}' is running Junos {found_version} \u2014 expected {target_version}.\"\n        )\n    }\n\n# \u2500\u2500 Emit JSON to stdout (captured as stdout_json by the platform) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nprint(json.dumps(result))",
                 "data": {
-                  "target_version": "$var.job.formData#/target_version",
+                  "target_version": "$var.job.target_version",
                   "device_results": "$var.a2.mop_template_results"
                 },
                 "safety": {
@@ -865,13 +865,7 @@
               "outgoing": {
                 "result": ""
               },
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/data/target_version",
-                  "displayPath": ".target_version"
-                }
-              ]
+              "decorators": []
             },
             "actor": "Pronghorn",
             "groups": [],
@@ -900,21 +894,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Pre and Post Checks",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Pre and Post Checks",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.preCheckOutput"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -936,20 +924,14 @@
             "displayName": "ConfigurationManager",
             "variables": {
               "incoming": {
-                "name": "$var.job.formData#/device",
+                "name": "$var.job.device",
                 "options": {}
               },
               "outgoing": {
                 "status": null
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/name",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -971,21 +953,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Verify Image",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Verify Image",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.verifyImageResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -1107,21 +1083,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Stage Upgrade",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Stage Upgrade",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.stageUpgradeResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -1171,21 +1141,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Version Check",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Version Check",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.versionCheckResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -1299,21 +1263,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Reboot",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Reboot",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.rebootResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -1381,21 +1339,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Pre and Post Checks",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Pre and Post Checks",
+                "variables": "$var.b63a.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.postCheckResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -1578,24 +1530,51 @@
               "y": 1620
             }
           },
-          "85cd": {
-            "name": "makeData",
-            "canvasName": "makeData",
-            "summary": "Cast to JSON",
-            "description": "This task takes an input and converts it to a different data type. For example, converting a number into a string.",
+          "b63a": {
+            "name": "merge",
+            "canvasName": "merge",
+            "summary": "Variable Object",
+            "description": "Merge data into a single object",
             "location": "Application",
             "locationType": null,
             "app": "WorkFlowEngine",
-            "type": "automatic",
-            "displayName": "Tools",
+            "type": "operation",
+            "displayName": "WorkFlowEngine",
             "variables": {
               "incoming": {
-                "input": "$var.job.formData",
-                "outputType": "json",
-                "variables": ""
+                "data_to_merge": [
+                  {
+                    "key": "device",
+                    "value": {
+                      "task": "job",
+                      "variable": "device"
+                    }
+                  },
+                  {
+                    "key": "target_version",
+                    "value": {
+                      "task": "job",
+                      "variable": "target_version"
+                    }
+                  },
+                  {
+                    "key": "image_path",
+                    "value": {
+                      "task": "job",
+                      "variable": "image_path"
+                    }
+                  },
+                  {
+                    "key": "image_sha256",
+                    "value": {
+                      "task": "job",
+                      "variable": "image_sha256"
+                    }
+                  }
+                ]
               },
               "outgoing": {
-                "output": "$var.job.formData"
+                "merged_object": ""
               }
             },
             "actor": "Pronghorn",
@@ -1614,7 +1593,7 @@
             }
           },
           "workflow_start": {
-            "85cd": {
+            "b63a": {
               "state": "success",
               "type": "standard"
             }
@@ -1744,7 +1723,7 @@
               "type": "standard"
             }
           },
-          "85cd": {
+          "b63a": {
             "a2": {
               "state": "success",
               "type": "standard"
@@ -1754,11 +1733,35 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "formData": {
-              "title": "input",
-              "type": "string",
-              "examples": [
-                "33"
+            "target_version": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "device": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": [
+                      "Cisco ASA",
+                      "Cisco NX-OS"
+                    ]
+                  }
+                },
+                {
+                  "title": "name",
+                  "type": "string",
+                  "examples": [
+                    "xr9kv-atl"
+                  ]
+                }
               ]
             },
             "_id": {
@@ -1767,29 +1770,93 @@
               "examples": [
                 "12476bef62224efb97684e43"
               ]
+            },
+            "image_path": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "image_sha256": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
             }
           },
           "required": [
-            "formData",
-            "_id"
+            "target_version",
+            "device",
+            "_id",
+            "image_path",
+            "image_sha256"
           ]
         },
         "outputSchema": {
           "type": "object",
           "properties": {
-            "formData": {
-              "title": "output",
+            "target_version": {
               "type": [
                 "array",
-                "string",
                 "boolean",
+                "null",
                 "number",
-                "object"
+                "object",
+                "string"
+              ]
+            },
+            "device": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": [
+                      "Cisco ASA",
+                      "Cisco NX-OS"
+                    ]
+                  }
+                },
+                {
+                  "title": "name",
+                  "type": "string",
+                  "examples": [
+                    "xr9kv-atl"
+                  ]
+                }
               ]
             },
             "_id": {
               "type": "string",
               "pattern": "^[0-9a-f]{24}$"
+            },
+            "image_path": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "image_sha256": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
             },
             "initiator": {
               "type": "string"
@@ -2241,8 +2308,8 @@
         "type": "automation",
         "font_size": 12,
         "createdVersion": "6.4.0",
-        "lastUpdatedVersion": "4.69.69",
-        "last_updated": "2026-06-02T03:09:03.274Z",
+        "lastUpdatedVersion": "5.55.5",
+        "last_updated": "2026-06-25T10:18:09.852Z",
         "last_updated_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
@@ -2252,22 +2319,22 @@
         "created": "1970-01-01T00:00:00.000Z",
         "preAutomationTime": 0,
         "sla": 0,
-        "uuid": "b675b3f5-eca8-4eb7-be6e-ba9535725995",
+        "uuid": "a63333bf-5479-46a8-a3c0-1dacdfa96c03",
+        "canvasVersion": 3,
         "created_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
           "firstname": "Mike",
           "inactive": false
         },
-        "canvasVersion": 3,
         "tags": [],
         "groups": [],
-        "migrationVersion": 7
+        "migrationVersion": 8
       }
     },
     {
       "iid": 38,
-      "reference": "8bf53e31-fcf7-421d-a217-2c154e5cb96e",
+      "reference": "e12afde2-c824-492f-b76a-794d1eeda432",
       "type": "workflow",
       "folder": "/Golden Configuration",
       "document": {
@@ -2546,7 +2613,7 @@
         "scenarios": [],
         "type": "automation",
         "font_size": 12,
-        "last_updated": "2026-06-02T03:09:03.274Z",
+        "last_updated": "2026-06-24T20:03:06.844Z",
         "last_updated_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
@@ -2554,7 +2621,7 @@
           "inactive": false
         },
         "lastUpdatedVersion": "4.69.69",
-        "uuid": "f6ebada7-804a-4f25-b9b2-d0b12b878736",
+        "uuid": "9d48564f-80c2-40c5-a95e-b897050c0314",
         "created": "2026-05-31T20:05:43.869Z",
         "created_by": {
           "provenance": "CloudAAA",
@@ -2566,12 +2633,12 @@
         "canvasVersion": 3,
         "tags": [],
         "groups": [],
-        "migrationVersion": 7
+        "migrationVersion": 8
       }
     },
     {
       "iid": 39,
-      "reference": "c9a2fce6-4de8-4325-8a2b-10d24197a737",
+      "reference": "8d63cf1e-a93a-419f-bde8-a42a3bf20244",
       "type": "workflow",
       "folder": "/Inventory Management",
       "document": {
@@ -3190,9 +3257,9 @@
         "scenarios": [],
         "type": "automation",
         "font_size": 12,
-        "last_updated": "2026-06-02T03:09:03.274Z",
+        "last_updated": "2026-06-24T20:03:06.844Z",
         "lastUpdatedVersion": "4.69.69",
-        "uuid": "cb518afd-c1cf-4960-897d-30b02fb8d74c",
+        "uuid": "512b9055-e2c8-4a17-b3f2-d34dd8f5afa5",
         "createdVersion": "5.55.5",
         "name": "Create & Update Inventory from NetBox",
         "last_updated_by": {
@@ -3202,21 +3269,21 @@
           "inactive": false
         },
         "created": "1970-01-01T00:00:00.000Z",
+        "canvasVersion": 3,
         "created_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
           "firstname": "Mike",
           "inactive": false
         },
-        "canvasVersion": 3,
         "tags": [],
         "groups": [],
-        "migrationVersion": 7
+        "migrationVersion": 8
       }
     },
     {
       "iid": 40,
-      "reference": "2f0ea1c3-c50f-4d44-a059-65f07c5d5be1",
+      "reference": "2494ad56-105b-44e6-96c8-6120b442f60d",
       "type": "workflow",
       "folder": "/Inventory Management",
       "document": {
@@ -3394,9 +3461,9 @@
         "scenarios": [],
         "type": "automation",
         "font_size": 12,
-        "last_updated": "2026-06-02T03:09:03.274Z",
+        "last_updated": "2026-06-24T20:03:06.844Z",
         "lastUpdatedVersion": "4.69.69",
-        "uuid": "9497efd3-4b3a-43c3-a737-cb2fd75a5e28",
+        "uuid": "970643a5-f94e-4bc8-a896-c93665f550c6",
         "createdVersion": "5.55.5",
         "name": "Clear & Delete Inventory",
         "last_updated_by": {
@@ -3406,21 +3473,21 @@
           "inactive": false
         },
         "created": "1970-01-01T00:00:00.000Z",
+        "canvasVersion": 3,
         "created_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
           "firstname": "Mike",
           "inactive": false
         },
-        "canvasVersion": 3,
         "tags": [],
         "groups": [],
-        "migrationVersion": 7
+        "migrationVersion": 8
       }
     },
     {
       "iid": 44,
-      "reference": "8ca88bbb-d106-4e3c-8763-d120f1b932b8",
+      "reference": "3e29ac6b-ef29-4728-b164-d4ab594526a6",
       "type": "workflow",
       "folder": "/Port Turn Up",
       "document": {
@@ -3439,18 +3506,12 @@
             "displayName": "ConfigurationManager",
             "variables": {
               "incoming": {
-                "name": "$var.job.formData#/device"
+                "name": "$var.job.device"
               },
               "outgoing": {
                 "device": ""
               },
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/name",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "actor": "Pronghorn",
             "groups": [],
@@ -3464,7 +3525,7 @@
             "groups": [],
             "nodeLocation": {
               "x": 0,
-              "y": -468
+              "y": -576
             }
           },
           "a2": {
@@ -3479,21 +3540,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Port Turn Up Pre Check",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Port Turn Up Pre Check",
+                "variables": "$var.d009.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.preCheckOutput"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -3515,20 +3570,14 @@
             "displayName": "ConfigurationManager",
             "variables": {
               "incoming": {
-                "name": "$var.job.formData#/device",
+                "name": "$var.job.device",
                 "options": {}
               },
               "outgoing": {
                 "status": null
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/name",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -3604,21 +3653,15 @@
             "displayName": "MOP",
             "variables": {
               "incoming": {
-                "template": "@6a1de7f998f25fd9d4056c91: Port Turn Up Post Check",
-                "variables": "$var.job.formData",
-                "devices": "$var.job.formData#/device"
+                "template": "@6a138e0000000000ffff0001: Port Turn Up Post Check",
+                "variables": "$var.d009.merged_object",
+                "devices": "$var.job.device"
               },
               "outgoing": {
                 "mop_template_results": "$var.job.postCheckResults"
               },
               "error": "",
-              "decorators": [
-                {
-                  "type": "query",
-                  "pointer": "/incoming/devices",
-                  "displayPath": ".device"
-                }
-              ]
+              "decorators": []
             },
             "groups": [],
             "actor": "Pronghorn",
@@ -3721,8 +3764,8 @@
             "displayName": "TemplateBuilder",
             "variables": {
               "incoming": {
-                "name": "@6a1de7f998f25fd9d4056c91: 802.1Q Sub Interface",
-                "variables": "$var.job.formData",
+                "name": "@6a138e0000000000ffff0001: 802.1Q Sub Interface",
+                "variables": "$var.d009.merged_object",
                 "castDataType": "string"
               },
               "outgoing": {
@@ -3840,6 +3883,74 @@
               "x": 0,
               "y": 420
             }
+          },
+          "d009": {
+            "name": "merge",
+            "canvasName": "merge",
+            "summary": "Variables Object",
+            "description": "Merge data into a single object",
+            "location": "Application",
+            "locationType": null,
+            "app": "WorkFlowEngine",
+            "type": "operation",
+            "displayName": "WorkFlowEngine",
+            "variables": {
+              "incoming": {
+                "data_to_merge": [
+                  {
+                    "key": "device",
+                    "value": {
+                      "task": "job",
+                      "variable": "device"
+                    }
+                  },
+                  {
+                    "key": "interface",
+                    "value": {
+                      "task": "job",
+                      "variable": "interface"
+                    }
+                  },
+                  {
+                    "key": "vlan_id",
+                    "value": {
+                      "task": "job",
+                      "variable": "vlan_id"
+                    }
+                  },
+                  {
+                    "key": "description",
+                    "value": {
+                      "task": "job",
+                      "variable": "description"
+                    }
+                  },
+                  {
+                    "key": "ip_address",
+                    "value": {
+                      "task": "job",
+                      "variable": "ip_address"
+                    }
+                  },
+                  {
+                    "key": "zone",
+                    "value": {
+                      "task": "job",
+                      "variable": "zone"
+                    }
+                  }
+                ]
+              },
+              "outgoing": {
+                "merged_object": ""
+              }
+            },
+            "actor": "Pronghorn",
+            "groups": [],
+            "nodeLocation": {
+              "x": 0,
+              "y": -468
+            }
           }
         },
         "transitions": {
@@ -3850,7 +3961,7 @@
             }
           },
           "workflow_start": {
-            "6476": {
+            "d009": {
               "state": "success",
               "type": "standard"
             }
@@ -3915,27 +4026,24 @@
               "state": "success",
               "type": "standard"
             }
+          },
+          "d009": {
+            "6476": {
+              "state": "success",
+              "type": "standard"
+            }
           }
         },
         "inputSchema": {
           "type": "object",
           "properties": {
-            "formData": {
+            "device": {
               "anyOf": [
                 {
                   "title": "name",
                   "type": "string",
                   "examples": [
                     "xr9kv-atl"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {},
-                  "examples": [
-                    {
-                      "device_name": "Cisco IOS-XR"
-                    }
                   ]
                 },
                 {
@@ -3949,31 +4057,77 @@
                   }
                 }
               ]
+            },
+            "interface": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "vlan_id": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "ip_address": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "zone": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
             }
           },
           "required": [
-            "formData"
+            "device",
+            "interface",
+            "vlan_id",
+            "description",
+            "ip_address",
+            "zone"
           ]
         },
         "outputSchema": {
           "type": "object",
           "properties": {
-            "formData": {
+            "device": {
               "anyOf": [
                 {
                   "title": "name",
                   "type": "string",
                   "examples": [
                     "xr9kv-atl"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {},
-                  "examples": [
-                    {
-                      "device_name": "Cisco IOS-XR"
-                    }
                   ]
                 },
                 {
@@ -3986,6 +4140,56 @@
                     ]
                   }
                 }
+              ]
+            },
+            "interface": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "vlan_id": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "ip_address": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
+              ]
+            },
+            "zone": {
+              "type": [
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
               ]
             },
             "_id": {
@@ -4145,11 +4349,11 @@
         "type": "automation",
         "font_size": 12,
         "createdVersion": "6.4.0",
-        "lastUpdatedVersion": "4.69.69",
-        "last_updated": "2026-06-02T03:09:03.274Z",
+        "lastUpdatedVersion": "5.55.5",
+        "last_updated": "2026-06-25T09:16:13.314Z",
         "preAutomationTime": 0,
         "sla": 0,
-        "uuid": "fe6528ac-a72c-483c-8a7c-a37c06b3f6e9",
+        "uuid": "9769f0c9-2da1-4061-a009-1c1459849733",
         "last_updated_by": {
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
@@ -4166,16 +4370,16 @@
         },
         "tags": [],
         "groups": [],
-        "migrationVersion": 7
+        "migrationVersion": 8
       }
     },
     {
       "iid": 45,
-      "reference": "6a1e494d98f25fd9d4056ca5",
+      "reference": "6a1e30c698f25fd9d4056ca4",
       "type": "template",
       "folder": "/Port Turn Up",
       "document": {
-        "_id": "6a1e494d98f25fd9d4056ca5",
+        "_id": "6a1e30c698f25fd9d4056ca4",
         "name": "802.1Q Sub Interface",
         "type": "jinja2",
         "command": "",
@@ -4185,9 +4389,9 @@
         "description": "",
         "version": 1,
         "created": "2026-06-02T01:24:22.337Z",
-        "lastUpdated": "2026-06-02T03:09:03.336Z",
+        "lastUpdated": "2026-06-24T20:03:06.837Z",
         "createdBy": {
-          "_id": "6a0c557474e890f65883e175",
+          "_id": "6a3c303cdd8730559c46dc8b",
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
           "firstname": "Mike",
@@ -4195,7 +4399,7 @@
           "email": "mike.elrom@itential.com"
         },
         "lastUpdatedBy": {
-          "_id": "6a0c557474e890f65883e175",
+          "_id": "6a3c303cdd8730559c46dc8b",
           "provenance": "CloudAAA",
           "username": "mike.elrom@itential.com",
           "firstname": "Mike",
@@ -4207,17 +4411,31 @@
   ],
   "created": "2026-05-24T23:30:00.000Z",
   "createdBy": {
-    "_id": "6a0c557474e890f65883e175",
+    "_id": "6a3c303cdd8730559c46dc8b",
     "provenance": "CloudAAA",
     "username": "mike.elrom@itential.com"
   },
-  "lastUpdated": "2026-06-02T03:10:14.726Z",
+  "lastUpdated": "2026-06-30T12:03:25.471Z",
   "lastUpdatedBy": {
-    "_id": "6a0c557474e890f65883e175",
+    "_id": "6a3c303cdd8730559c46dc8b",
     "provenance": "CloudAAA",
     "username": "mike.elrom@itential.com"
   },
   "folders": [
+    {
+      "nodeType": "folder",
+      "name": "Inventory Management",
+      "children": [
+        {
+          "iid": 39,
+          "nodeType": "component"
+        },
+        {
+          "iid": 40,
+          "nodeType": "component"
+        }
+      ]
+    },
     {
       "nodeType": "folder",
       "name": "Software Upgrade",
@@ -4254,20 +4472,6 @@
     },
     {
       "nodeType": "folder",
-      "name": "Inventory Management",
-      "children": [
-        {
-          "iid": 39,
-          "nodeType": "component"
-        },
-        {
-          "iid": 40,
-          "nodeType": "component"
-        }
-      ]
-    },
-    {
-      "nodeType": "folder",
       "name": "Golden Configuration",
       "children": [
         {
@@ -4289,15 +4493,15 @@
           "nodeType": "component"
         },
         {
+          "iid": 44,
+          "nodeType": "component"
+        },
+        {
           "iid": 47,
           "nodeType": "component"
         },
         {
           "iid": 45,
-          "nodeType": "component"
-        },
-        {
-          "iid": 44,
           "nodeType": "component"
         },
         {
@@ -4307,8 +4511,45 @@
       ]
     }
   ],
-  "iid": 45,
-  "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAwAAAAMACAYAAACTgQCOAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAKZBJREFUeNrs3fF108i+AODZe/b/9asA3wrIVoC2AkIF61RAqABTQaCChAoCFcRUkFBBvBWQrYAXPaQXI+TEGo1kyfq+c3S4cNeyNBqPfr+Z0SgEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYl98UATBQs/vtqMF/f3e/3Sg2oGdHRXuVyyr/34sd95G3Xf9u/H1V/LkuNsZfN3axkgAAhxrQbwb2mzfHrIPv3Lx55n/+s5EoSBiAXc2Ldivfnm38fdbT95dt2U3Rjt30GSzyUz3YvPZ/bNzPmnZaNU0K/pIAAEOXbdwojzoK7lPfWL8UN9WboMcNtGE/thc9B/pNlYnAl+LPO5cuidnGvev5RtC/T78NdmcTbBiaZnBdZOvLnj5DN2WbB5oXB3azzA7gfO4qN9VDGynIIuppV0nRvNj4OagTyPUrr4PH99vLkbdheXv1+X77FHRkNL3+m/ewIbZJYvaBBHnfG25dBd3fIza60/RaXI30PPPekcX9dnm/fYush2Pabu+38yJAmGI9XQ6sPZ3adlVsZ0V5DTVAGWPQd3q/XR9wvVmE4Y5euP5iNwmABEACMBJZEQhPORj7VgRi8wnVUwnAcOvi1UZSwG6Oi86LKdWTpaTxp86rMSZ9SAAkABKA3uUN5q2Aq/b6HU+gnkoAxrNd6vV9NPCbejt2PtG6MS/Ofcwj1kn9R5sA7BD4n+s9qpUVAddtOJzpQYzb8Uagc6le/n+SqR37uU1fTuR8y8D/VmIsAQB2C2yv3TAb3WTyYCsfEThSHAwoGbiccPBzXJz7W4HfT2ZFmdyGw546tizuYwuXXAIAPH1jOBPItk6czgQcDCxBLXtBTydyvldF8jN3+Z8sp7MDO6+joh2W+EkAgB0bzauJBAhdO5VEMeAE/5B7fstVXTKXu3GZzQ/oXLS9EgBgBwsBa2cJ1UJRMDDz8NDzeyg9pLMDPKe+26uxB87n4fBGMzrzuyIAwX/RcNJNUFKuuvFecTAweW9pPk/+VRj3y+7yoHWf033WG9s/xb899jK39ZZjnW0E4M/Cw9tn+0poyiTqTRjXCyrL4x5y8nL3xG8skwAAUwn+yxvkl5obZnkzjbkRHFUCg9nGzXS+pyAh75XKXyd/osoxMPORBn2bbVifvf6ros26Kdqo2MRpW/v26ZEA8ahoR7IO27HZxj1hDPVhn8H/qrhnfd34+y7B/q6yLfc19mgZvAeANNdjn+8BWIR+18vPfwPHYRjzTLONwKHPF8IsR1pPlwNrT23dbIsRBv99tF2nAwzA5uHhbexdnXs2gjpw1eM97GxA9zAkABIACUCUo44by+swrreTzsLD+uldvyhoMcJ6KgGQBEwp+C+f3ZmNqP1adNCZ8S0Mu+e5y7fS324E/AfJFCCYnllHicf6fvsYfgwbr0dWJvmQ7afwMPye3/ReF41/6iAgv2ndhHHPud63dwd+fuWUtX0M/Y9h+scipJ+6eFec84eRtl8XxZZ3urxN1PmS1798hOHPsP15hn3WgS6S1YviPrbSzFJnGYwAkOZ67GMEIPWQ8SGvdFP2rKUeFbgN++1dHPsIwNTMi4BuWfzevoXuRwKG2vO5COl7uZfh8FYOykK66TFXA/w9fFMHkAC4eUoAdnecOIg9ntC1XSS+6ZyNqJ5KAIYZ4J2F7qasDXH6R+qpi1MI+k4TtVtDej/MlTqABEACIAHY3SxhsLCc6PUtX6Q09ofsJACH5Th08zDk9YDOcZ4wAb8K03qQcx7SPB8wH0hdT1W3rayDBIBJJADLkKbXX6P5I3BPEYxcjaSeSgDGUy9TJwJDSfZTBLD5b3bKbzo/D+OfCpSiE8vLwpAAMJkEYJYgYL0OhkqrZZoiKFlIALRhHSQCKacG7TvpTzHqpsc3TRKwz2mfizCdVa6QAEgAJABJnAr+B5sE3EoAtGEd1c1UyyTus+c3S3T82q80ScDtHo+7bVIr+EcCwOQSgDYNp+C/+yQgkwBowzqyCON+XqVt0HeuCiRPAvYRSLdNBAX/SABcvsklAG0azm+C/52TgDaByqUEQBs28CRgH6MAyyD471Jsx8U+RgHaJCzm/CMBcPOcZALQpuHMXNKdtV2icDbgeioBkAT03R7MQ7vnlgT/3ZbxoucOlkNYyWpQ/qMI4ODFPrR1EbwNsYn8zb5t3lC7UIR0KP89n7Tcx+sej/dti6Q4/y2+ccmftG7RZvVZF9o8eHziMpPSMhgBIM316HoEIHbNZFN/4sVOBboacD1ddngsS21Yr9o+GDzv4RjnwbTFPsUuHdvXqkqxb683CvQIIwBw2F5Efu7D/Xan+KLE9qhlAhd6kPeMr1t2KnTtbYvPvtJ29dZm/d3T8WUt6joSAJik2IbzvaKLdtEiwMoUHx3Lg+M20yK6DvrmIX46XN5urVzixlaR5bbo4djyUYaYjpELiaAEAKZqFuKGaDWc7cX2qL1QdPQU8H1qEZDNOzy22N7/dWj3DI42K+4e0/WIUBb5uQ8uqQQApip2fuZHRddabHCVKTp60mZ6RFdBX5uAMh/V0HHRLim8ifjcy46PK6ZT5CbyXCQAwEGICSbXwRB6CnkgctFj0gYxv/XYRLWrkarjEDfdY6XdSiKm1zzr+Jhi2kSdWBIAmLTnkTdS0vjSY+IGMT4OrI7GLi1pqcc0YhLCeei242LuPiYBALpvOL8otr3eTEMwCkC/dXQd8blZSP8cwFGIf2Zp7VImcRfZbnWVEGaR52D6jwQAJi3mZrpSbElvpjE3omeKjgkmqrGrC3nYM63PEZ/pakpYTJLpHiYBgEmLaTjzgHWt6JKKSQCMADD0gK+Lehrz8O8q6O0dQkKYDeg+9tUllACABKD7YJX0N6O5YqNHq8jPpez1jV1a1MOe6cWMXHYxJSznOTYJABDRIDdl/n96MUmVBIAxJAEp31qdRQaqFy7dYOpDFyOXs8h6gQQAJss0kvEmAKmDK+gi+U/ZxsSsJf/JZTvY+lCa99jmSgCAyVopguRie6MkcPRpvefvzyI+4+Hf7sQE0V08CNw0AdD7LwGAyXuuCEZ9M4UxJABZgu+O2YelHruvD02D6fkAjludkADA5MVMIdF4diOmV2qu2JhI4BSTAJj+M7w6kbrNMg1SAgAMOFClGxIApvLbj5k6YsGC7u37OYCYfa1dNgkAwJhvpNC3fQVPWcRnjAAMMyncd6/9Py6bBACmzkOkQNcJQNbyO2PaqZtgtLIPN3uoD0gAgJaa9sSsFNmg/KEImIDYBIBhJoRIAADoOTCCsZlHfMaUuuEmAClXn/MQsAQAADhAMQ8AGwHoT9OpVimDdp0gEgCASd1EYSrmEoBBa1rW++61X7lkEgCAsd5EQQLgtzRGeu0lAADAgVv1HCyuFXmvlLcEAAA4YLMRfN9Xl6lX1tWXAAAAB6zv6RtZxGfWLtPgZYpAAgAAkIoEoF8WMJAAAAAHKrb3f9XiO2PWjJcA9MtD1xIAAOBAzUbynRIAkAAAAAlkEZ/ROwwSAABgpJ5FfKbt/PCmScfKZRoF7wKQAAAAI5BFfOaLYjt4MUnXTLFJAACAYcsDtnnE59aKDiQAAMD4HEd+rs0zAPOevw+o+F0RAMBkvRxJApCPVGQuF0gAAIB4eVAdMwKw2sOxLooNSMAUIACYptjpPx4ABgkAADBCryM/90nRgQQAABiXLMSt2Z6v/++BXJAAAAAj8zbycyl6/+eKHyQAAEB/FiF+RZ2PEgCQAAAA45Gv/HMW+dl12M8KQIAEAACIdFkkATE+Kj6QAAAA47EM8VN/8od/3ytCkAAAAOOwCPEP/uY+FUkAIAEAAEYQ/J+3+Hwe+L9TjHA4flcEAHCw8gd+T1vu40P48QDwPl3cb/+4nIO3UgQSAABgP+bhR69/1nI/eeA/hLn/HwWXkI4pQABwWPIe/+sEwX/uTTD3Hw6OEQAAOAyL8ONB33mi/V2ENG/+rbpxqUACAADEmRWB/+uQ9g27eZD+pqNjNqIAEgAAoIE80D++314Uf3YRoJ8I1EECAAD0Lws/evmP7rfnG3/vUh78D22azlxVAAkAANN1deDnd9RDkP9Y8P9pgGUiAQAJAAATlimCzoL/C8UAh88yoAAwbXc9B/9rRQ77ZQQAAKYrD8ZfhX7n/MckAH+4VJCOEQAAmKZ8rv+fYRzr8h+5XCABAADilFN+XgVLfYIEAAA4aBf323/D/h/2bTrqMHPpQALAD3NFAECDwH8oL/hqegymAEFCHgIet7UiAOCRIDuf5//O/QLYZAQAAA5LPr0m7+kve/yHGPx/ifhM5tJCGkYAAGDc8p7+1f32ufhzrUgACQAAHI4yyP9a/O+bEZ5DzDFnxfkCEgAAJhgAH7q7IsAPRbC/uR3K+TX1TNUHCQAA0/SXIphkEjdXbJCGh4ABgH1oOgqQKTKQAAAA4xXzHMBcsYEEgDheqALAGBMA9y+QABDJK9W7kUV85k6xARP1T8RnXig2kAAggBy7r4oAmKjYpUABCYAGVBEAMEKriM/kU4CMYoMEAAAYKaMAIAGgJxrPbswVAUDnCcBLxQYSgKlbK4JRJwCmcAFT9iXiM5liAwnA1MWsouB16sPhIW5gylYRn5kHy4GCBICoxpP0LE8H0Mw6xI1k/63oQAIwZauIz+g56casp+sHcEg+RXxmodhAAkDzQNUyaulJrACai3kOYCYJAAnAlK0Eq6MN/j0ADPBjBCDmeSjTgEACMGkxDWem2PaeAHgAGOAhCYi5j7mXgQRgsmJ6kp8rtqRiyvOLYgP4P58jP2cUACQAEoAGjhVbUlnEZ9aKDeD/xE4DWgRTWkECMFFfIz8nCUhjHnkDkgAAPLiI/NyZogMJwBTFPkzqdeppxCZSK0UH8P8+RH4uCzq0QAIw0QQgZug0bzAtB9re35HXDIAH6xDfMXLmfgYSgCmKaTSto9xeFuKm/6wUHcAv3kV+bn6/vVV8IAGYmtgVZV4rulb+7vl6ARyyVYjvIDkNpgKBBGBiPkV+bn6/LRVflLznf9HiJgfAr961+Ox5sCoQSAAmZB3i55XnowDmTjYXu/JE7HJ3AFOwCvGdJLMiCXBPSytPqpaKQQLAMH1s2WCyu3yoOYv87GfFB/CoNqMAebB6JQlIer+7Dj+esThVHBIAmumjx/dTi88e+2E3urm83dN1ApiCVYh/L4AkII1ZUYabo935/84UjQSA3fWx7OO6ZXCZ/7AXLtWTDWKb4eWLYPoPwC7etGwvJQHx8k7B2y3B/qUylQAwPB9afv4seIDqseD/qmX5fFSMADvJg/+Tlvsok4C54tz5Pnf5RJBf/jdIABiQVWi3wkz+w87n+i0UZfLgv+21AZiafFT7IkESkN/XLBH6uHwa8O2O5ZQFDwVLABicdwn2ce7H/dPNo23wn+q6AExNPhWo7TTastfaG4Prg/nriLJ5G6b3PMCsOOdyM2NiYvLA+HvDre8fyWXEMdZtUx86zXtEviUqxz4N/fimdnMd2vVoejxddgbEtKdMz1GitjjfboMHWUNxb28bK3zrKEYYWpyVPVJW38aYWBoBOOwek7tElf62+DFOqdek7PVP9aN+o0oCRMtHAE4S7WtetO9T7eDKz/k87D7d5zFTeB7gPDzMAsjv5X/eb78V21/hxxS1RaLyZOBiMuZ99DacJuot2cxyDz0RKBvGlOW23MN5GAEYjiwYAXjMMhgBYHeLxO3z96LNn0+kLbrsoPy+h/TLiMe0C13EWec7nl+ZVH4PnqE8aFcjumF18WP/Fg7vdevHkdf1qe16T+cjAZAASACQBDT/3R1aD+4sPDzc+72jrYs3Lw8hAVhWAvqz8DBytLktN87/MnQ3LQoJQOMf/3WHP/zbMN6lQ4+LhutbR2Wzz0ZAAiABkAAgCYhvu8e8JPasKJ/LDsuoLKfjAbULKROAeU3bd1XEPJvBfxk/XG+U/a176uGKCaj3ad5hkFttDC6LH0w2wAYxK47tqoey+L7nm4cEQAIgAUASkG7EexGG3atb3t+uQz/3t66fn9h3AnBWXPtZJQGoawsvK99f1ssh15fwu/YjStPAbr3n482//6/Q/RsRZ0VvQL693fjufPsSfjyUXC7lturo+482GsM/ir/P9/BDPAn9vP0ZYKouivtLl2+mLXvTFxv3tLxt/1rcx9Y93+PL+1y+Pd/4333J7+P5ktbvJ9Bx8ynstpjKh/DzSMinImk8HnI5SQD6C8D37aZIAi57DobL4PuxzLxNMjALwxumPQntX1wDwNNWxb2tr+fSynvaZkdXeY8tO7n+rfxbm/vaH+Hnjq19+lTc3+4mUK/yMv+443/7ciM5Kv9chYEvmCIBiMsKxypvjPLlq1K81EqZ/ir/0b8K3vYL0Pe97a8iID/d0zEMJUjvwroI/FcTrFdVf99vL2qStVUY2ai/9wDEZf9NfRlYkJonAe9dyk5uQIJ/gP3c294U7fBacSQr0zzw/+9E7211HaWzyv+fb++KejcqEoB+EoAhyhvKV2EaQ3lde1/8+M35B9ivPFDVydU+8H9XBP4XEy2D/H7+fMu//1Vsr4p/e1aTJGRDj68kAM29iGyQhuhT8QPXUMZZF43AmyCRAhhSAPsmTLfnOkXgv5z4fS2vN8fh8Xn8q/DwFuBs49+PN2IsCcABOYr8UWko3VwA6M86PPTWaqsfL6cTgf9PPoSHl6g9puwAPCv+nn/mbXhYIUoCcEDBf8xT3TcjaQDyRvLPYAWbx8qoDPyNmgCMw6q4v015SkudvIf61Ua5CPx/vt+/K4L5RfFvH8OvKwOVi398Dj+miJdvRT5RhIclz4ybvpjieqTnOi/Ot8vXh49lu9poAMbCi8CGIwteBJa6XYU2yp7dvl6aNaTtujj3+QHGW1kHx3Fe7PupkYB5eHjJ6MJP7PDENBbnB3De+cjH2cSSgbE0khIACYAEANp1dh16MjDG+9lQEoDNJOC2KMejSvtevjU4347HUsDeA9CskYiZ///1AM79ptjeFGWQV/iXIX5K1BCtw49h4i9hBHP3drCKuMZ0V7feRXymS+86rk9D2Tfs8lt7X2zzjftbNuL72+b9bNe32Y79HtZlu5lP58mn/rwOD3P9N+Xl+6GoQ6Mp69/89nd2FuJeMPLngQdX1VeSZyM45ruNpObrgQT8AKRVJgRDvr+V97MvG/c197PubL6lebP8R0cCsPsFv43oDcgrxv9MtNGch4cRgufFn9UfTh+9B3lD+E/x5zrEv5odAKr3t3Jp8C5HxO827l1fw8+dWO5nSAA6tAw/ngRv6iJ4Evwx2Q7ZdZ1tjd5KkQKwZ3XJQJk4bLPaEvQDe8z28wc7Yh68WSg+AAAYl8sQ/+T9TPEBAMB4nLYI/i8VHwAAjMdRaLfu7rEiBACA8QT/sfP+y5dFAAAAEwj+PfwLAAAjsUgQ/Ov9BwCAgctX6zlrGfjr/QcAgBHIH9a9TRT8XytOAAAYpux+u0oU+JfbkWIFAIDhyKf6LMKPnvrvibel4gUAgGEE/fk0n/PQ/gHfbduVYgYAYAx+O9CAP5+Kk91vL4o/u3Rzv/11v92pTsBIVNvFu6It6+O7bnZoL8t2vGurEV2zebF1dc2qZb4utiEff7ax32eV/Ze+bNS7m8TnVHdeMdYdHNfY2qOjog5uu475tfu3KKebDtsrRtIY5pVmEX5Mv8l74VM9zLvr9i3BDx+gb322ZdXvynYMCPpow3c95r63ulHlZc1/N0t4nU4r+75MXA/OK/s/j0xSFsWxtVmq+zxhgrnsIK7Ir3++MuFxwuNaJkwU66ZRNz3WLLSfmXFZ1IeZJr253/f0vUc7VpZqJthXr9CuGfuriWftwGGYFTfTPxXFYH26395W/i2/j14k2v/Lmn3n9SLV6Hb1nv+5Yf3ME5TXCYK9eRE05tvqfnsXhjUSNCuC46w453VxjBcDObarmjjspKifTdqaLFGdOi6Spfz73wSzMQavr96drrZrGScwYn0uZmAEIN1zZdVR7vNE12gWun2vzXH4tZe7SbzQ9ej+ZYt7+rKnOtH0GJcd/LYvW9aRo9Dds5hlvTrWvO/md0XQ2IUsEzhQeQ/zKoxrbvyU5L2cp5XA+iRRgF7nZUjT8/yy5jx2sdghySmfJSjniFc9KwLPoyfOP///X4Xhzi0vr9GrPX3/eU09ed+gfsweSWLuijbna6h/Rqic/fEsPDz3se07xGYD11fvTurM8tSlAw7AU23drMPvyiLvEWMs12Xi/R+F9nOv6zw2pz5FXbiNOObFE3X0LDSbEry5IuBj+206zXgZ0q4KmBWxxrZRj9PI42pTF+vK7LxlOZXlvYg4nnlRDtVnEc407RKALoZj5y4bMIEEIPUDoBKAtFJPA5o9URcWLfd/FJFUPBYjLEOa5wC2vQi06RTf1AnAptMtQXOfCcBpguA/hF+n/sQkW9vqynXxuzA1WwKQbLsN3S8jCrDvQLWuh++0o++SALRzFuLn09dZdJwMnjXc3yzU936nChifCm6b9iR3mQBsO8bjiONaJqobMed3FNkONE3qkAAkCfwXLhMwkQRgW9B11MF3SQDaOU4cTF3WBHgpy75ar566ty57Cv6fSoB2LdOuE4C6MjyLOK5lgnKJXQDltCbGYs/+owh+kj+YlL/U679hGEtuAfQhf3Cu7uHC82BYfYj3qeqDji8j91XOi990siXpiJEH7fOa43/seF7X/Ht+X+7q4dz8Xv++5t9fD+yaV8u1S0fh12k+bV56Wm1D1n7GEoAhyCt1vqrP/xQ3wJUiASbcFlYDAQ/WDTMJSBGgH9fsd12z/9gE4+8dkpdNi5pg8X3ofmWedzVB6XEYzrSSL5W/d3lc+W/+qqaDIDb4RwIwGOsi4z8pgv4/iwZGxQamLm8LVzVBmbW1h+VzTUAY0yv8cst+P3eUYHxpmDCUwXnX7rZ8z1Dq/V1PCUAZ/M8E/3QlC/2u4HNW3MTmih7g0Tne+c2/bsWOeaLvyiLvEWMs12WH31W9RmcJjne+UQfaLjc6f2T/deq+87zn6/ctNJ/PvwzdPwMQ83tYNqyLeflfh26evTgNaR9cJ4FDGAEoXyCxKjL4N+FhHv9vxf/O/+0imHcGsEubelITHJwrmkFpOw2o+t/fbNwjy/vqppcJ978tyK36vOcyzQZ67VPHMrMicakG+6lejHZT831LP+H9+n2PlbfJsN5dTQVauXwAnQVC+XSg00owtHTjHow8OF5s/H1ebLsGh9WA/mPN/rNKQN/krcN/P7H/qqMdAvK+y7Ss9/uON7IOE4Btwf9JwvNeFXHc5tSit8W/vfdTBoB+7Dqd4Dq0X3LSFKBu1E2ZafLuhup0l3nl/5+H+GlAdZ+dP/GZ6nKk13u4fjHnvAzdTwGqls0uo3HLHeti3TtAFh2cwzJsn6a9CPTOKkAAbJP3At7VBAyWBt2//LpUe8j/3vGzx5VrWDc9Zx1+HXl/2WD/4Yn91yU01e/vW913Hu35Oh+F5g9T7+p8S/Ddxe97GeqnE2XFcXwrEp3TAZT5JPyuCADYolwadLPHcV78/VXPx5K6ZzWfknIx8uvzuRIcluvuPxU8PzX9Z/PfjyqB/S7TgKqJyCri3L7usc4PJQDd9uxNiqlR24L/3NvwsCRsSn+F+ulG5bkeV+rzqrge/xR/rgIAEK3p9JrLED/dJNUUoNTbsodyXXZ8HWOnAT01/Wcz2Wt6/eo+czTAsnss0WxyHMvQzRSgvJzr3s6962pPy0fOYxF2W0GxK8uaOrjrdl2UQXUUi4aMAADwlJPw61td817CVej+JU1sV04D2uw1zXvfH3uwsho4rcP2nt51+LVH/GV4vCf2eMs+pmIW4lYPmhfbs+Lz8y3Xo+17EfLgv+4tv+vKtcuKZLKLh3SXxX7z73sdmo24HBVbmejm9f9DMDoAAE+KecA2C/W9cbOG35VFfpcRgO0BXfV7H7sm1Yc+n+pRrq7hfvvEf38Z4nqsD2UEoKut6Zr8y5rzOH7kN5z6/R9Nk6bj4hivQtzowFXwrqdGjAAAsItV+NH7+Hbj346Kv7/p4fv/Sry/9YFcl0/h1x7dPJi62PLfV3voP+6w/80gfl5c95tHArkm+2e3395Jyzr7PPzobd90E35+y+9JkcBtXs/zDn57VeVI1qdKPZsXnQHPwkPP/2OdBtfFsRqVBIAabZbYvArNlkq0DGj3qsu1Xu5YrreR+9/Wq78I8W98vQpGAL7XXMdF5Hk8dVzbRhTaPO/TtTLBLFcN2nZec03804wAANDESfh16k9+Q16FX5cMpR91q/XMaq5HdfWfXVeT+Vyz/7pRn9j913m2p7LMWn5+HZqNeryt/D3/HX3o+PeU73dbT/lJUQbVl3Z1sSpQzHGXIwUnRWLytnKss+LfTjQLAPCztr3rdXOJr3b8rl0CrCwYAWhiHnZ7mVN1VZld55QfhadX9qlbkei4wTlchv5Wodkm5hyWLY+7+kzGbUizus0yxD9L0OT3vW9HoX40wApBT/AiMACaynvg3tcE7UtFsxfr8PRLu6qrONV9Zpu6F3n9XRM0bqp7UdljvtbUp77VfWfXo1pvKt+RX6PTjr/vZoff96easjkdYN3Pz+XVjtcSCQAALb2rCSTeBm/x3JePTwRAf9cEeU2TvscC/rbTf24GEMS9qPm3VcffmQf/H2p+R/MOviufFnPR4L+96+m42lrV1B/tkAQAgI4Cl7ogIZ/KYfi9f9WAu7oiTzVg/9IywZhXgqxqsP45IogLTyQVXTvuOfgvLcOvIyznib/jfWj25uv8d/2qpk5dDrT+rzQBEgAA+pH3ur2rCQzPFU3v1mH7NKDq9J+m03PKa73eEjDXvZW16f7vao5/0WP5ZeHX3u3PPX7/Sc3xHCfc/7+RQXV1qt9RGOZUv381ARIAAPrzPtRPD1komt6ttgTobaf/bPvcy8qfbfdfHWXIk4q+5p2/3eF8u7521et3NoA69a4m8RviVL8//PwlAAD0q24q0FkwD7dvdQH0cfi1J/lzov2XIwup9n+xJTCfd1xueZKR1QTk6z38jjbl573cc526C/VLag5tlE9bAwBP6GKJzaxmv9fBMqB9qy71WX2x1beO9992CcazLfWoq+dKti0jme34+WVIu1zmMqR5sdUycV08G0j9rjMP7ZagBQAJQMLg5bsEoHdnT5T/ecf7b/uQ6GxLQN5FEpBt+a7zFnX+qoPzv0zwW1wmOK7b8PT7IOpcFWXaVRJ3GbwHAAD2lgCEUN/rLwHoz9ET5d+2ZzR7Yv+LBOdwvGXftyHd0qDLR75j1mI/KV6YtQjxIxJdJQDbrv31E585DT+PZuTHMU9Y3887SEIBQALQ0DzU96pKAPpz+0j5p+gZfez6pgruTsPjoxgxiUD5UPG28tnlLbl9JAB1ifR1y+NKVRebTAV6LBm9LBKd2Pp4HOqnn30PngfYye+KAICE1uHHQ4Ope+GuOjjWXd6KOkarUN8Tn69qk+LNtp+27L9uqdBY7zcCzqpFsa2Lc/0nbF8Hfl5sL58IDPNy+WtA9eFNpc4fFcnL+z0f17si+dosy7dFnbipSbjutgT55cPp58XnborreLOljpbX8UXx3dsSh5MD/U0DQGt99K7XDc23GQHoYss6Ltflnq7vtik0i473f9rRuXzruB5chfie6GXoZgSg7jf0rcFxLjusi3U9+9tGKGbFd3/r4fe8CADAXhOAbQ8NSgD6URdwzTre/7zDutRFEHkb2j8T0WUCMK855/PI40pdF5cN63t5DW87+B1fd/BbBgAJQKQjCcDeVHuPLzve/3UP51TO4b9qGfSfh+4eJk49VW0ZWW+XPdTFugf+j3ZsF87C0wsGPLZ9K66j5T4j/aYIACCJamC2Dv2/TGozyNoMjlZh+zz5Ie5/1/Iu54M/D/UjHF+KP8t55uuJ1MV5+HlEZj3gc88qx/ui5r/Jr92/xTmU1xIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABiH/xVgALPQu3+UZjTWAAAAAElFTkSuQmCC",
+  "iid": 5,
+  "thumbnail": "",
   "backgroundColor": "#FFFFFF",
-  "referencedComponentHashes": []
+  "referencedComponentHashes": [
+    {
+      "type": "automation",
+      "reference": "6a13a94c84f0ff3625737607",
+      "name": "JUNOS Software Upgrade",
+      "hash": "4f4a11f259a6f112431a7b3a82b5165a3ad46805"
+    },
+    {
+      "type": "automation",
+      "reference": "6a1de1efc48aa7c8f6876601",
+      "name": "JUNOS Compliance",
+      "hash": "ea95339ad5a4a9f6d040347ad59742160403c756"
+    },
+    {
+      "type": "trigger",
+      "reference": "6a13a94c84f0ff3625737608",
+      "name": "JUNOS Upgrade",
+      "hash": "5e9c74418df6c7b1c6ce201e119b61694ff2157a"
+    },
+    {
+      "type": "automation",
+      "reference": "6a1e409ac48aa7c8f6876603",
+      "name": "JUNOS Port Turn Up",
+      "hash": "0c05f69e55ccb75738d500b9dbf81ccdd24bec5f"
+    },
+    {
+      "type": "trigger",
+      "reference": "6a1de360c48aa7c8f6876602",
+      "name": "Version",
+      "hash": "01132025fff4f6049f1a0adf4f89f5fcf7602dd7"
+    },
+    {
+      "type": "trigger",
+      "reference": "6a1e40afc48aa7c8f6876604",
+      "name": "Port Turn Up",
+      "hash": "b9658d1ae385811dde0be0a47d6f55f13a642237"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Syncs `Juniper/JUNOS/Projects/Juniper JUNOS.project.json` from the live platform export
- **JUNOS Upgrade**: replaces `makeData` (Cast to JSON) with `merge` (Variables Object) extracting `device`, `target_version`, `image_path`, `image_sha256`; updates 8 shared tasks with new project ID and variable references (`$var.job.formData#/field` → `$var.b63a.merged_object` / `$var.job.field`)
- **Port Turn Up**: adds new `merge` task extracting `device`, `interface`, `vlan_id`, `description`, `ip_address`, `zone`; updates 5 shared tasks with new project ID and variable references
- All other components (7 mopCommandTemplates, 3 jsonForms, 1 template, 3 other workflows) verified identical — no changes

## Test plan
- [ ] Import project from this file into a fresh platform instance and verify JUNOS Upgrade workflow runs end-to-end
- [ ] Verify Port Turn Up workflow correctly uses the new merge task for variable passing