### PR TITLE
docs: split content standards out of CONTRIBUTING.md into STANDARDS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,45 @@
-# Code Contribution Guidelines
+# Contributing to Itential Assets
 
-We welcome and appreciate contributions to our project! To ensure high-quality and consistent contributions, please follow the guidelines below.
+Thank you for your interest in contributing to Itential Assets! We welcome and appreciate contributions to this project. This document covers the process for contributing; see [`STANDARDS.md`](./STANDARDS.md) for the detailed content rules each asset type needs to follow.
 
-## What We Look For
+## Table of Contents
 
-All asset types below live at `{Vendor}/[{Product}/]{AssetType}/`. The `{Product}` segment only applies to vendors with more than one product (e.g., `AWS/EC2/OpenAPIs/`) — single-product vendors omit it (e.g., `Kentik/OpenAPIs/`).
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Contribution Standards](#contribution-standards)
+- [Before You Submit](#before-you-submit)
+- [Naming Your Pull Request](#naming-your-pull-request)
+- [How to Submit](#how-to-submit)
+- [Getting Help](#getting-help)
 
-### Studio Projects (`{Vendor}/[{Product}/]Studio Projects/`)
-- Examples - Examples of how to perform reusable generic tasks.
-- Sample Use Cases - An example of an orchestrated workflow that utilizes your contribution example.
-- When submitting a Sample Use Case, include a corresponding Automation and Trigger (_when applicable_).
-- Files are exported Studio projects in `.project.json` format.
+## Code of Conduct
 
-### Automations (`{Vendor}/[{Product}/]Automations/`)
-- Exported automation definitions that correspond to a Studio Project submission.
-- Should be paired with a Trigger where applicable.
+By participating in this project, you are expected to uphold our [Code of Conduct](./CODE_OF_CONDUCT.md). Please read it before contributing.
 
-### Golden Configurations (`{Vendor}/[{Product}/]Golden Configurations/`)
-- Template examples that illustrate an OS or the consumption of JSON returned from an API call (in the case of JSON Compliance).
+## Getting Started
 
-### OpenAPIs (`{Vendor}/[{Product}/]OpenAPIs/`)
-Imported into Itential Platform as Integration Models.
+1. **Fork the repository** on GitHub.
+2. **Clone your fork** locally.
+3. **Create a topic branch** for your change.
+4. **Make your changes**, following the rules in [`STANDARDS.md`](./STANDARDS.md) for the asset type(s) you're touching.
+5. **Verify your contribution** — import it into a running Itential Platform (or Itential Gateway, for device drivers) instance and confirm it behaves as described.
+6. **Submit a pull request** against `devel`.
 
-- Version 2.x or 3.x OpenAPI specifications in `.json` format.
-- **Filename convention**: `{snake_case_title}-{version}.json`, with exactly one hyphen separating the title from the version (e.g., `cisco_meraki_dashboard-1.48.0.json`). The title portion must use lowercase `snake_case` only — no spaces, camelCase, or PascalCase.
-- **Version labeling**:
-    - The version segment must be exactly the value in that spec's `info.version` field (e.g., `info.version: "3.7.8"` → `netbox-3.7.8.json`; `info.version: "v2"` → `servicenow_table_api-v2.json`).
-    - To mark a spec as the actively-maintained, most current one, overwrite `info.version` to `"latest"` and rename the file to match (e.g., `cisco_meraki_dashboard-latest.json`). Since this overwrites the vendor's real version number, preserve it in an `x-vendor-api-version` field (e.g., `"x-vendor-api-version": "1.48.0"`) so it isn't lost — see any existing `-latest.json` spec for an example.
-    - Never use an underscore in place of the separating hyphen (e.g., `meraki_1.48.0.json` is incorrect; `meraki-1.48.0.json` is correct).
-- `info.title` must contain only the integration name — no version numbers (e.g., `Cisco Meraki Dashboard`, not `Cisco Meraki Dashboard v1.48`).
-- `info.version` must reflect the actual API version (use `"latest"` to match a `-latest.json` filename).
-- **File size**: The spec must be under 15MB.
-- **One auth method defined**: Only one `securityScheme` should be defined. Itential Platform supports a single authentication method per integration instance, so additional schemes will not be usable. If a vendor's API supports multiple incompatible auth methods (e.g., an API key header vs. a Bearer token), publish separate specs with distinct filenames (e.g., `cisco_meraki_dashboard-latest.json` vs. `cisco_meraki_dashboard_bearer_variant-latest.json`) rather than combining schemes in one spec.
-- **Global security block encouraged**: Define security at the top level of the spec rather than on individual operations. Per-operation overrides are supported but the global block is preferred for consistency.
-- **Supported auth method**: The `securityScheme` must use an auth type supported by Itential Platform. See the [Itential Platform Security Schemes documentation](https://docs.itential.com/itential-platform/admin-essentials/integrations/auth/security-schemes) for the full list of supported methods.
-- **No duplicate specs**: Don't leave an old, differently-named spec in the same folder once a renamed/enriched replacement exists — update the product's `README.md` links and remove the superseded file in the same contribution.
+## Contribution Standards
 
-### LCM Resource Models (`{Vendor}/[{Product}/]LCM Resource Models/`)
-- Examples of Use Cases resource models.
+Every asset type in this repo — Studio Projects, Automations, Golden Configurations, OpenAPIs, LCM Resource Models — has its own naming, versioning, and structural rules, plus a set of requirements that apply repo-wide (branding, README structure, no sensitive data, etc.). These all live in [`STANDARDS.md`](./STANDARDS.md).
+
+**Read it before opening a PR** — most review feedback traces back to one of these rules.
 
 ## Before You Submit
 
-### Cleanly Organized
-- The Assets should be modular (_where possible_) and well-structured.
-- Follow best practices for readability, maintainability, and scalability.
-- Use clear, descriptive variable and Asset names.
-- Aim for automation workflows that can be reused in different contexts.
-- Ensure workflows are documented and easy to understand.
-
-### Housekeeping Items
-- Tested against the current GA release of Itential Platform.
-- Free from Errors
-- Include enough detail so that others can easily replicate the setup.
-- Clearly explain what your contribution does.
-- Describe why it is valuable and how it improves or complements existing functionality.
-- **Keep the root `README.md` in sync**: If your contribution adds a new vendor, a new product under an existing vendor, or a new asset type, update the corresponding table in the repo's root [`README.md`](./README.md) (the Vendor Index and/or Asset Type table) in the same contribution.
-
-## Additional Requirements
-
-- **No Sensitive Data**: Ensure your contribution does not contain any sensitive or private data (e.g., API keys, passwords, personal information).
-- **Proper Spelling and Grammar**: Proofread your contribution to make sure it is free of spelling and grammar errors.
-- **Title Case**: Use Title Case for headings, function names, and any other key titles.
+- [ ] Tested against the current GA release of Itential Platform.
+- [ ] Free from errors.
+- [ ] Includes enough detail so that others can easily replicate the setup.
+- [ ] Clearly explains what your contribution does, why it's valuable, and how it improves or complements existing functionality.
+- [ ] No sensitive or private data included (see [`STANDARDS.md`](./STANDARDS.md#repo-wide-requirements)).
+- [ ] Root [`README.md`](./README.md) updated if your contribution adds a new vendor, a new product under an existing vendor, or a new asset type (update the Vendor Index and/or Asset Type table).
+- [ ] Reviewed against the relevant sections of [`STANDARDS.md`](./STANDARDS.md) for the asset type(s) you're contributing.
 
 ## Naming Your Pull Request
 
@@ -73,7 +52,7 @@ Title your PR (and its commits) as `<type>(<scope>): <summary>`.
   | `feat` | A new asset: a new vendor, product, or asset (OpenAPI spec, Studio Project, Automation, Golden Configuration) |
   | `fix` | A correction to an existing asset (bad workflow task, wrong variable reference, invalid operationId, broken spec field, etc.) |
   | `chore` | Non-functional maintenance (renaming, removing duplicates, reorganizing folders, metadata-only edits) |
-  | `docs` | Changes to `README.md`, `CONTRIBUTING.md`, or a product's own `README.md` only |
+  | `docs` | Changes to `README.md`, `CONTRIBUTING.md`, `STANDARDS.md`, or a product's own `README.md` only |
 
 - **`scope`** — the lowercase, hyphenated vendor or vendor-product the change applies to, matching the folder it lives in (e.g. `junos`, `panorama`, `servicenow`, `servicenow-change-management`). Omit the product part for single-product vendors. If a PR spans multiple vendors, drop the scope.
 - **`summary`** — imperative mood, lowercase, no trailing period, describing what changed (e.g. `add commit-all operation`, not `added` or `this PR adds`).
@@ -89,5 +68,11 @@ Examples:
 - Submit a pull request with a detailed description of your contribution.
 - Make sure your contribution is fully tested and documented.
 - Address any review comments promptly to ensure a smooth review process.
+
+## Getting Help
+
+- **Resources**: Start with the root [`README.md`](./README.md) for repo structure and import instructions, [`STANDARDS.md`](./STANDARDS.md) for content rules, and the target product's own `README.md` for asset-specific details.
+- **Issues**: Search [existing issues](https://github.com/itential/assets/issues) before opening a new one.
+- Otherwise, open a [new issue](https://github.com/itential/assets/issues/new) describing what you're trying to do or the problem you've hit.
 
 We value your efforts and look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Minimum versions vary by asset - check each product's `README.md` for specifics.
 
 ## Contributing
 
-Have an asset to share? Sanitize it and follow the guidelines in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Have an asset to share? Sanitize it and follow the guidelines in [CONTRIBUTING.md](./CONTRIBUTING.md). See [STANDARDS.md](./STANDARDS.md) for the detailed content rules each asset type needs to follow.
 
 ---
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,62 @@
+# Itential Assets — Content Standards
+
+This document holds the detailed content and authoring rules for every asset type in this repo. [`CONTRIBUTING.md`](./CONTRIBUTING.md) covers the contribution *process* (forking, branching, PR naming, submitting); this document covers what a contribution actually needs to look like before it's ready for review.
+
+All asset types below live at `{Vendor}/[{Product}/]{AssetType}/`. The `{Product}` segment only applies to vendors with more than one product (e.g., `AWS/EC2/OpenAPIs/`) — single-product vendors omit it (e.g., `Kentik/OpenAPIs/`).
+
+## Table of Contents
+
+- [General Principles](#general-principles)
+- [Studio Projects](#studio-projects-vendorproductstudio-projects)
+- [Automations](#automations-vendorproductautomations)
+- [Golden Configurations](#golden-configurations-vendorproductgolden-configurations)
+- [OpenAPIs](#openapis-vendorproductopenapis)
+- [LCM Resource Models](#lcm-resource-models-vendorproductlcm-resource-models)
+- [Repo-Wide Requirements](#repo-wide-requirements)
+
+## General Principles
+
+- The Assets should be modular (_where possible_) and well-structured.
+- Follow best practices for readability, maintainability, and scalability.
+- Use clear, descriptive variable and Asset names.
+- Aim for automation workflows that can be reused in different contexts.
+- Ensure workflows are documented and easy to understand.
+
+## Studio Projects (`{Vendor}/[{Product}/]Studio Projects/`)
+- Examples - Examples of how to perform reusable generic tasks.
+- Sample Use Cases - An example of an orchestrated workflow that utilizes your contribution example.
+- When submitting a Sample Use Case, include a corresponding Automation and Trigger (_when applicable_).
+- Files are exported Studio projects in `.project.json` format.
+
+## Automations (`{Vendor}/[{Product}/]Automations/`)
+- Exported automation definitions that correspond to a Studio Project submission.
+- Should be paired with a Trigger where applicable.
+
+## Golden Configurations (`{Vendor}/[{Product}/]Golden Configurations/`)
+- Template examples that illustrate an OS or the consumption of JSON returned from an API call (in the case of JSON Compliance).
+
+## OpenAPIs (`{Vendor}/[{Product}/]OpenAPIs/`)
+Imported into Itential Platform as Integration Models.
+
+- Version 2.x or 3.x OpenAPI specifications in `.json` format.
+- **Filename convention**: `{snake_case_title}-{version}.json`, with exactly one hyphen separating the title from the version (e.g., `cisco_meraki_dashboard-1.48.0.json`). The title portion must use lowercase `snake_case` only — no spaces, camelCase, or PascalCase.
+- **Version labeling**:
+    - The version segment must be exactly the value in that spec's `info.version` field (e.g., `info.version: "3.7.8"` → `netbox-3.7.8.json`; `info.version: "v2"` → `servicenow_table_api-v2.json`).
+    - To mark a spec as the actively-maintained, most current one, overwrite `info.version` to `"latest"` and rename the file to match (e.g., `cisco_meraki_dashboard-latest.json`). Since this overwrites the vendor's real version number, preserve it in an `x-vendor-api-version` field (e.g., `"x-vendor-api-version": "1.48.0"`) so it isn't lost — see any existing `-latest.json` spec for an example.
+    - Never use an underscore in place of the separating hyphen (e.g., `meraki_1.48.0.json` is incorrect; `meraki-1.48.0.json` is correct).
+- `info.title` must contain only the integration name — no version numbers (e.g., `Cisco Meraki Dashboard`, not `Cisco Meraki Dashboard v1.48`).
+- `info.version` must reflect the actual API version (use `"latest"` to match a `-latest.json` filename).
+- **File size**: The spec must be under 15MB.
+- **One auth method defined**: Only one `securityScheme` should be defined. Itential Platform supports a single authentication method per integration instance, so additional schemes will not be usable. If a vendor's API supports multiple incompatible auth methods (e.g., an API key header vs. a Bearer token), publish separate specs with distinct filenames (e.g., `cisco_meraki_dashboard-latest.json` vs. `cisco_meraki_dashboard_bearer_variant-latest.json`) rather than combining schemes in one spec.
+- **Global security block encouraged**: Define security at the top level of the spec rather than on individual operations. Per-operation overrides are supported but the global block is preferred for consistency.
+- **Supported auth method**: The `securityScheme` must use an auth type supported by Itential Platform. See the [Itential Platform Security Schemes documentation](https://docs.itential.com/itential-platform/admin-essentials/integrations/auth/security-schemes) for the full list of supported methods.
+- **No duplicate specs**: Don't leave an old, differently-named spec in the same folder once a renamed/enriched replacement exists — update the product's `README.md` links and remove the superseded file in the same contribution.
+
+## LCM Resource Models (`{Vendor}/[{Product}/]LCM Resource Models/`)
+- Examples of Use Cases resource models.
+
+## Repo-Wide Requirements
+
+- **No Sensitive Data**: Ensure your contribution does not contain any sensitive or private data (e.g., API keys, passwords, personal information).
+- **Proper Spelling and Grammar**: Proofread your contribution to make sure it is free of spelling and grammar errors.
+- **Title Case**: Use Title Case for headings, function names, and any other key titles.


### PR DESCRIPTION
## Summary
- Splits `CONTRIBUTING.md` into two focused docs: `CONTRIBUTING.md` (contribution process) and a new `STANDARDS.md` (detailed content/authoring rules per asset type + repo-wide requirements).
- Adds a Table of Contents to `CONTRIBUTING.md` (and to the new `STANDARDS.md`), links the previously-unreferenced `CODE_OF_CONDUCT.md`, and adds lightweight "Getting Started" and "Getting Help" sections.
- No content rules were changed in meaning — existing per-asset-type rules (Studio Projects, Automations, Golden Configurations, OpenAPIs, LCM Resource Models) and repo-wide requirements moved verbatim into `STANDARDS.md`.
- Root `README.md`'s Contributing section now also links to `STANDARDS.md`.

Deliberately **not** added, since no supporting tooling exists in this repo: a CLA section, CI-enforced branch/commit-message rules, PR labels/Release Drafter docs, or a named-maintainer/email contact.

## Test plan
- [ ] Confirm every rule from the previous `CONTRIBUTING.md` appears in exactly one of `CONTRIBUTING.md` or `STANDARDS.md`
- [ ] Click through both files' Table of Contents links on GitHub to confirm anchors resolve
- [ ] Confirm `README.md`, `CODE_OF_CONDUCT.md`, `LICENSE` links resolve from `CONTRIBUTING.md`/`STANDARDS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)