### PR TITLE
feat: Add pipeline functionality to deploy assets to cloud env

### DIFF
--- a/.github/scripts/deploy.py
+++ b/.github/scripts/deploy.py
@@ -54,72 +54,61 @@ class AssetDeployer:
 
         print(f"🚀 Deploying to {environment} environment")
 
-    def find_asset_files(self) -> dict[str, list[Path]]:
-        """Scan repository for asset files in bundle structure.
+    # Maps each asset directory name (must match diff.sh's ASSET_DIRS) to the
+    # bucket key, emoji, and label used when reporting found files.
+    _ASSET_DIR_MAP = {
+        "Studio Projects": ("projects", "📦", "Studio project"),
+        "Automations": ("automations", "🤖", "automation"),
+        "LCM Resource Models": ("lifecycle_manager_resources", "🔧", "LCM resource model"),
+        "Golden Configs": ("configurations", "⚙️ ", "golden config"),
+    }
 
-        If CHANGED_FILES env var is set (JSON array of repo-relative paths),
-        only files in that list are returned. Otherwise all files are returned.
+    def find_asset_files(self) -> dict[str, list[Path]]:
+        """Find asset files to deploy.
+
+        If CHANGED_FILES env var is set (JSON array of repo-relative paths
+        from diff.sh), those exact files are used directly — diff.sh already
+        determined what changed, so no filesystem walk is needed. Otherwise,
+        every asset file in the repo is found via a full glob (manual run).
 
         Returns:
             Dictionary mapping asset types to list of file paths
         """
         repo_root = Path.cwd()
 
-        changed_raw = os.environ.get("CHANGED_FILES", "")
-        changed_files: set[str] | None = None
-        if changed_raw:
-            try:
-                changed_files = set(json.loads(changed_raw))
-            except json.JSONDecodeError:
-                pass
-
-        def is_changed(path: Path) -> bool:
-            if changed_files is None:
-                return True
-            return str(path.relative_to(repo_root)) in changed_files
-
         assets: dict[str, list[Path]] = {
             "projects": [],
-            # "agent_projects": [],
             "automations": [],
             "lifecycle_manager_resources": [],
             "configurations": [],
         }
 
-        for studio_dir in repo_root.glob("**/Studio Projects"):
-            if studio_dir.is_dir():
-                for f in studio_dir.glob("*.json"):
-                    if is_changed(f):
-                        assets["projects"].append(f)
-                        print(f"📦 Found Studio project: {f.name}")
+        changed_raw = os.environ.get("CHANGED_FILES", "")
+        changed_files: list[str] | None = None
+        if changed_raw:
+            try:
+                changed_files = json.loads(changed_raw)
+            except json.JSONDecodeError:
+                pass
 
-        # for ap_dir in repo_root.glob("**/Agent Projects"):
-        #     if ap_dir.is_dir():
-        #         for f in ap_dir.glob("*.json"):
-        #             if is_changed(f):
-        #                 assets["agent_projects"].append(f)
-        #                 print(f"🤖 Found Agent project: {f.name}")
+        if changed_files is not None:
+            for rel_path in changed_files:
+                f = repo_root / rel_path
+                mapping = self._ASSET_DIR_MAP.get(f.parent.name)
+                if mapping is None:
+                    continue
+                bucket, emoji, label = mapping
+                assets[bucket].append(f)
+                print(f"{emoji} Found {label}: {f.name}")
+            return assets
 
-        for om_dir in repo_root.glob("**/Automations"):
-            if om_dir.is_dir():
-                for f in om_dir.glob("*.json"):
-                    if is_changed(f):
-                        assets["automations"].append(f)
-                        print(f"🤖 Found automation: {f.name}")
-
-        for lm_dir in repo_root.glob("**/LCM Resource Models"):
-            if lm_dir.is_dir():
-                for f in lm_dir.glob("*.json"):
-                    if is_changed(f):
-                        assets["lifecycle_manager_resources"].append(f)
-                        print(f"🔧 Found LCM resource model: {f.name}")
-
-        for cm_dir in repo_root.glob("**/Golden Configs"):
-            if cm_dir.is_dir():
-                for f in cm_dir.glob("*.json"):
-                    if is_changed(f):
-                        assets["configurations"].append(f)
-                        print(f"⚙️  Found golden config: {f.name}")
+        # No CHANGED_FILES set — full-repo run, walk the tree.
+        for dir_name, (bucket, emoji, label) in self._ASSET_DIR_MAP.items():
+            for asset_dir in repo_root.glob(f"**/{dir_name}"):
+                if asset_dir.is_dir():
+                    for f in asset_dir.glob("*.json"):
+                        assets[bucket].append(f)
+                        print(f"{emoji} Found {label}: {f.name}")
 
         return assets
 

--- a/.github/scripts/deploy.py
+++ b/.github/scripts/deploy.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Deployment script for promoting Itential assets using asyncplatform.
+
+This script reads asset files from the repository and imports them into
+the target Itential Platform environment using the asyncplatform library.
+
+Currently supports:
+    - Studio projects
+    - Operations Manager automations
+    - Lifecycle Manager resources
+    - Configuration Manager golden configs
+
+Usage:
+    python deploy.py <environment>
+
+Required environment variables:
+    HOST              - Itential Platform hostname
+    CLIENT_ID         - OAuth service account client ID
+    CLIENT_SECRET     - OAuth service account client secret
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import asyncplatform
+from asyncplatform.models.projects import ProjectMember
+
+class AssetDeployer:
+    """Handles deployment of Itential assets to a target environment."""
+
+    def __init__(self, environment: str, members: list[dict[str, str]] | None = None):
+        """Initialize deployer with environment configuration.
+
+        Args:
+            environment: Target environment name
+            members: Optional list of project members with username, type, and role
+        """
+        self.environment = environment
+        self.members = members or []
+        self.host = os.environ.get("HOST")
+        self.client_id = os.environ.get("CLIENT_ID")
+        self.client_secret = os.environ.get("CLIENT_SECRET")
+
+        if not all([self.host, self.client_id, self.client_secret]):
+            raise ValueError(
+                "Missing required environment variables: "
+                "HOST, CLIENT_ID, CLIENT_SECRET"
+            )
+
+        print(f"🚀 Deploying to {environment} environment")
+
+    def find_asset_files(self) -> dict[str, list[Path]]:
+        """Scan repository for asset files in bundle structure.
+
+        If CHANGED_FILES env var is set (JSON array of repo-relative paths),
+        only files in that list are returned. Otherwise all files are returned.
+
+        Returns:
+            Dictionary mapping asset types to list of file paths
+        """
+        repo_root = Path.cwd()
+
+        changed_raw = os.environ.get("CHANGED_FILES", "")
+        changed_files: set[str] | None = None
+        if changed_raw:
+            try:
+                changed_files = set(json.loads(changed_raw))
+            except json.JSONDecodeError:
+                pass
+
+        def is_changed(path: Path) -> bool:
+            if changed_files is None:
+                return True
+            return str(path.relative_to(repo_root)) in changed_files
+
+        assets: dict[str, list[Path]] = {
+            "projects": [],
+            # "agent_projects": [],
+            "automations": [],
+            "lifecycle_manager_resources": [],
+            "configurations": [],
+        }
+
+        for studio_dir in repo_root.glob("*/Studio Projects"):
+            if studio_dir.is_dir():
+                for f in studio_dir.glob("*.json"):
+                    if is_changed(f):
+                        assets["projects"].append(f)
+                        print(f"📦 Found Studio project: {f.name}")
+
+        # for ap_dir in repo_root.glob("*/Agent Projects"):
+        #     if ap_dir.is_dir():
+        #         for f in ap_dir.glob("*.json"):
+        #             if is_changed(f):
+        #                 assets["agent_projects"].append(f)
+        #                 print(f"🤖 Found Agent project: {f.name}")
+
+        for om_dir in repo_root.glob("*/Automations"):
+            if om_dir.is_dir():
+                for f in om_dir.glob("*.json"):
+                    if is_changed(f):
+                        assets["automations"].append(f)
+                        print(f"🤖 Found automation: {f.name}")
+
+        for lm_dir in repo_root.glob("*/LCM Resource Models"):
+            if lm_dir.is_dir():
+                for f in lm_dir.glob("*.json"):
+                    if is_changed(f):
+                        assets["lifecycle_manager_resources"].append(f)
+                        print(f"🔧 Found LCM resource model: {f.name}")
+
+        for cm_dir in repo_root.glob("*/Golden Configs"):
+            if cm_dir.is_dir():
+                for f in cm_dir.glob("*.json"):
+                    if is_changed(f):
+                        assets["configurations"].append(f)
+                        print(f"⚙️  Found golden config: {f.name}")
+
+        return assets
+
+    async def deploy_projects(self, client: Any, project_files: list[Path]) -> None:
+        """Deploy Studio projects to the platform.
+
+        Args:
+            client: Asyncplatform client instance
+            project_files: List of project file paths
+        """
+        if not project_files:
+            print("ℹ️  No Studio projects to deploy")
+            return
+
+        projects_resource = client.resource("projects")
+
+        for project_file in project_files:
+            with open(project_file, "r") as f:
+                project_data = json.load(f)
+            project_name = project_data.get("name", project_file.stem)
+
+            try:
+                print(f"📥 Importing project: {project_name}")
+
+                # Convert members dict to ProjectMember objects
+                # Support both schemas: account (username) and group (name)
+                members = []
+                for member in self.members:
+                    member_data = {
+                        "type": member["type"],
+                        "role": member["role"]
+                    }
+                    # Use "username" for accounts, "name" for groups
+                    if member["type"] == "account":
+                        member_data["username"] = member["username"]
+                    else:  # type == "group"
+                        member_data["name"] = member["name"]
+
+                    members.append(ProjectMember(**member_data))
+
+                # Import project with members (overwrite if exists)
+                result = await projects_resource.importer(
+                    project_data,
+                    members=members,
+                    overwrite=True,
+                    skip_reference_validation=True
+                )
+                print(f"✅ Successfully imported project: {result['name']}")
+                if members:
+                    for member in members:
+                        member_identifier = (
+                            getattr(member, 'username', None) or
+                            getattr(member, 'name', 'unknown')
+                        )
+                        print(f"👤 Added {member.type} {member_identifier} as {member.role}")
+            except Exception as e:
+                print(f"❌ Failed to import project {project_name}: {e}")
+                raise
+
+    # async def deploy_agent_projects(
+    #     self, client: Any, bundle_files: list[Path]
+    # ) -> None:
+    #     agent_projects_resource = client.resource("agent_projects")
+    #     for bundle_file in bundle_files:
+    #         with open(bundle_file, "r") as f:
+    #             bundle_data = json.load(f)
+    #         bundle_name = bundle_data.get("name", bundle_file.stem)
+    #         try:
+    #             members = []
+    #             for member in self.members:
+    #                 member_data = {"type": member["type"], "role": member["role"]}
+    #                 if member["type"] == "account":
+    #                     member_data["username"] = member["username"]
+    #                 else:
+    #                     member_data["name"] = member["name"]
+    #                 members.append(ProjectMember(**member_data))
+    #             await agent_projects_resource.importer(bundle_data, members=members)
+    #             print(f"✅ Successfully imported Agent project: {bundle_name}")
+    #         except Exception as e:
+    #             print(f"❌ Failed to import Agent project {bundle_name}: {e}")
+    #             raise
+
+    async def deploy_automations(
+        self, client: Any, automation_files: list[Path]
+    ) -> None:
+        """Deploy Operations Manager automations to the platform.
+
+        Args:
+            client: Asyncplatform client instance
+            automation_files: List of automation file paths
+        """
+        if not automation_files:
+            print("ℹ️  No automations to deploy")
+            return
+
+        automations_resource = client.resource("automations")
+
+        for automation_file in automation_files:
+            with open(automation_file, "r") as f:
+                automation_data = json.load(f)
+            automation_name = automation_data.get("name", automation_file.stem)
+
+            try:
+                existing_automation = await automations_resource.get_automation_by_name(
+                    automation_name
+                )
+
+                if existing_automation:
+                    print(f"ℹ️  Automation already exists, skipping: {automation_name}")
+                    continue
+
+                print(f"📥 Importing automation: {automation_name}")
+                result = await automations_resource.importer(automation_data)
+                print(f"✅ Successfully imported automation: {result['name']}")
+            except Exception as e:
+                print(f"❌ Failed to import automation {automation_name}: {e}")
+                print(f"⚠️  Skipping {automation_name} and continuing deployment")
+    
+    async def deploy_lifecycle_manager_resources(
+        self, client: Any, resource_files: list[Path]
+    ) -> None:
+        """Deploy Lifecycle Manager resource models to the platform.
+
+        Args:
+            client: Asyncplatform client instance
+            resource_files: List of lifecycle manager resource file paths
+        """
+        if not resource_files:
+            print("ℹ️  No Lifecycle Manager resources to deploy")
+            return
+
+        lm_resource = client.resource("lifecycle_manager")
+        lifecyle_manager_resource_payload = {
+            "model":{} 
+            }
+        for resource_file in resource_files:
+            with open(resource_file, "r") as f:
+                resource_data = json.load(f)
+                lifecyle_manager_resource_payload["model"] = resource_data
+            resource_name = resource_data.get("name", resource_file.name)
+            
+            try:
+                existing_resource = await lm_resource.get_resource_by_name(resource_name)
+                if existing_resource:
+                    print(f"ℹ️  Resource model already exists, skipping: {resource_name}")
+                    continue
+
+                print(f"📥 Importing resource model: {resource_name}")
+                result = await lm_resource.importer(lifecyle_manager_resource_payload)
+                print(f"✅ Successfully imported resource model: {result['data']['name']}")
+            except Exception as e:
+                print(f"❌ Failed to import resource model {resource_name}: {e}")
+                raise
+
+    async def deploy_configurations(
+        self, client: Any, config_files: list[Path]
+    ) -> None:
+        """Deploy Configuration Manager golden configs to the platform.
+
+        Args:
+            client: Asyncplatform client instance
+            config_files: List of golden config file paths
+        """
+        if not config_files:
+            print("ℹ️  No Configuration Manager golden configs to deploy")
+            return
+
+        cm_resource = client.resource("configuration_manager")
+
+        for config_file in config_files:
+            with open(config_file, "r") as f:
+                config_data = json.load(f)
+            config_name = config_data.get("data", [{}])[0].get("name", config_file.stem)
+
+            try:
+                if await cm_resource.check_if_golden_config_exists(config_name):
+                    print(f"ℹ️  Golden config already exists, skipping: {config_name}")
+                    continue
+
+                print(f"📥 Importing golden config: {config_name}")
+                result = await cm_resource.import_golden_config([config_data])
+                print(f"✅ {result.get('message', f'Successfully imported golden config: {config_name}')}")
+            except Exception as e:
+                print(f"❌ Failed to import golden config {config_name}: {e}")
+                raise
+
+    async def deploy(self) -> None:
+        """Execute the deployment process."""
+        print(f"\n{'='*60}")
+        print(f"Starting deployment to {self.environment}")
+        print(f"{'='*60}\n")
+
+        # Find all asset files
+        assets = self.find_asset_files()
+
+        if not any(assets.values()):
+            print("⚠️  No assets found to deploy")
+            return
+
+        # Deploy assets via asyncplatform
+        async with asyncplatform.client(
+            host=self.host,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            verify=True,
+        ) as client:
+            print(f"\n✅ Connected to Itential Platform: {self.host}\n")
+
+            await self.deploy_projects(client, assets["projects"])
+
+            # await self.deploy_agent_projects(client, assets["agent_projects"])
+
+            await self.deploy_lifecycle_manager_resources(
+                client, assets["lifecycle_manager_resources"]
+            )
+
+            await self.deploy_automations(client, assets["automations"])
+
+            await self.deploy_configurations(client, assets["configurations"])
+
+        print(f"\n{'='*60}")
+        print(f"✅ Deployment to {self.environment} completed successfully!")
+        print(f"{'='*60}\n")
+
+
+def main():
+    """Main entry point for the deployment script."""
+    if len(sys.argv) != 2:
+        print("Usage: python deploy.py <environment>")
+        sys.exit(1)
+
+    environment = sys.argv[1]
+
+    # Read members from environment variable (JSON array)
+    members = []
+    members_json = os.getenv("PROJECT_MEMBERS")
+    if members_json:
+        try:
+            members = json.loads(members_json)
+        except json.JSONDecodeError as e:
+            print(f"⚠️  Invalid PROJECT_MEMBERS JSON: {e}")
+            print("Continuing without project members")
+
+    try:
+        deployer = AssetDeployer(environment, members=members)
+        asyncio.run(deployer.deploy())
+    except Exception as e:
+        print(f"\n❌ Deployment failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/deploy.py
+++ b/.github/scripts/deploy.py
@@ -86,35 +86,35 @@ class AssetDeployer:
             "configurations": [],
         }
 
-        for studio_dir in repo_root.glob("*/Studio Projects"):
+        for studio_dir in repo_root.glob("**/Studio Projects"):
             if studio_dir.is_dir():
                 for f in studio_dir.glob("*.json"):
                     if is_changed(f):
                         assets["projects"].append(f)
                         print(f"📦 Found Studio project: {f.name}")
 
-        # for ap_dir in repo_root.glob("*/Agent Projects"):
+        # for ap_dir in repo_root.glob("**/Agent Projects"):
         #     if ap_dir.is_dir():
         #         for f in ap_dir.glob("*.json"):
         #             if is_changed(f):
         #                 assets["agent_projects"].append(f)
         #                 print(f"🤖 Found Agent project: {f.name}")
 
-        for om_dir in repo_root.glob("*/Automations"):
+        for om_dir in repo_root.glob("**/Automations"):
             if om_dir.is_dir():
                 for f in om_dir.glob("*.json"):
                     if is_changed(f):
                         assets["automations"].append(f)
                         print(f"🤖 Found automation: {f.name}")
 
-        for lm_dir in repo_root.glob("*/LCM Resource Models"):
+        for lm_dir in repo_root.glob("**/LCM Resource Models"):
             if lm_dir.is_dir():
                 for f in lm_dir.glob("*.json"):
                     if is_changed(f):
                         assets["lifecycle_manager_resources"].append(f)
                         print(f"🔧 Found LCM resource model: {f.name}")
 
-        for cm_dir in repo_root.glob("*/Golden Configs"):
+        for cm_dir in repo_root.glob("**/Golden Configs"):
             if cm_dir.is_dir():
                 for f in cm_dir.glob("*.json"):
                     if is_changed(f):

--- a/.github/scripts/deploy_integrations.sh
+++ b/.github/scripts/deploy_integrations.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+while IFS= read -r spec; do
+  name=$(basename "$spec" .json)
+  title=$(jq -r '.info.title' "$spec")
+  version=$(jq -r '.info.version' "$spec")
+  version_id="${title}:${version}"
+
+  #size check for spec since this is not done when using ipctl to import
+  size_bytes=$(stat -c%s "$spec" 2>/dev/null || stat -f%z "$spec")
+  max_bytes=15728640  # 14.99 MB
+  if [ "$size_bytes" -gt "$max_bytes" ]; then
+    echo "⚠️  Skipping $name — spec too large ($(( size_bytes / 1048576 )) MB > 14.99 MB limit)"
+    continue
+  fi
+
+  if ipctl describe integration-model "$version_id" > /dev/null 2>&1; then
+    echo "🗑️  Deleting existing model: $version_id"
+    ipctl delete integration-model "$version_id" || true
+  fi
+
+  echo "📥 Importing integration: $name"
+  if ipctl import integration-model "$spec" --verbose; then
+    echo "✅ Successfully imported: $name"
+  else
+    echo "⚠️  Skipping $name (import failed)"
+  fi
+done < <(echo "$CHANGED_SPECS" | jq -r '.[]')

--- a/.github/scripts/deploy_integrations.sh
+++ b/.github/scripts/deploy_integrations.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+failed=0
+
 while IFS= read -r spec; do
   name=$(basename "$spec" .json)
   title=$(jq -r '.info.title' "$spec")
@@ -24,6 +26,12 @@ while IFS= read -r spec; do
   if ipctl import integration-model "$spec" --verbose; then
     echo "✅ Successfully imported: $name"
   else
-    echo "⚠️  Skipping $name (import failed)"
+    echo "❌ Failed to import: $name"
+    failed=$((failed + 1))
   fi
 done < <(echo "$CHANGED_SPECS" | jq -r '.[]')
+
+if [ "$failed" -gt 0 ]; then
+  echo "❌ $failed spec(s) failed to import"
+  exit 1
+fi

--- a/.github/scripts/diff.sh
+++ b/.github/scripts/diff.sh
@@ -11,6 +11,7 @@ echo "Diffing against merge base $BASE_SHA"
 # core.quotePath=false prevents git from quoting paths that contain spaces
 CHANGED_FILES=$(git -c core.quotePath=false diff --name-only --diff-filter=AM "$BASE_SHA" HEAD \
   | { grep -E "(${ASSET_DIRS})/.*\.json$" || true; } | jq -R . | jq -sc .)
+echo "changed_files: $CHANGED_FILES"
 {
   echo "changed_files<<EOF"
   echo "$CHANGED_FILES"
@@ -25,27 +26,10 @@ else
   echo "has_asset_changes=false" >> "$GITHUB_OUTPUT"
 fi
 
-DELETED_FILES=$(git -c core.quotePath=false diff --name-only --diff-filter=D "$BASE_SHA" HEAD \
-  | { grep -E "(${ASSET_DIRS})/.*\.json$" || true; } | jq -R . | jq -sc .)
-{
-  echo "deleted_files<<EOF"
-  echo "$DELETED_FILES"
-  echo "EOF"
-} >> "$GITHUB_OUTPUT"
-echo "Deleted assets: $(echo "$DELETED_FILES" | jq 'length')"
-
 # ── Integration spec diff ─────────────────────────────────────────────────────
 CHANGED_SPECS=$(git -c core.quotePath=false diff --name-only --diff-filter=AM "$BASE_SHA" HEAD \
   | { grep "${INTEGRATION_MODELS_DIR}/.*-latest\.json$" || true; } | jq -R . | jq -sc .)
-
-DELETED_SPECS=$(git -c core.quotePath=false diff --name-only --diff-filter=D "$BASE_SHA" HEAD \
-  | { grep "${INTEGRATION_MODELS_DIR}/.*-latest\.json$" || true; } | jq -R . | jq -sc .)
-{
-  echo "deleted_specs<<EOF"
-  echo "$DELETED_SPECS"
-  echo "EOF"
-} >> "$GITHUB_OUTPUT"
-echo "Deleted specs: $(echo "$DELETED_SPECS" | jq 'length')"
+echo "changed_specs: $CHANGED_SPECS"
 
 # Use heredoc format — GitHub Actions rejects bare JSON arrays as output values
 {

--- a/.github/scripts/diff.sh
+++ b/.github/scripts/diff.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:-}"
+ASSET_DIRS="Studio Projects|Agent Projects|Automations|LCM Resource Models|Golden Configs"
+INTEGRATION_MODELS_DIR="OpenAPIs"
+
+echo "Diffing against merge base $BASE_SHA"
+
+# ── Asset diff ────────────────────────────────────────────────────────────────
+# core.quotePath=false prevents git from quoting paths that contain spaces
+CHANGED_FILES=$(git -c core.quotePath=false diff --name-only --diff-filter=AM "$BASE_SHA" HEAD \
+  | { grep -E "(${ASSET_DIRS})/.*\.json$" || true; } | jq -R . | jq -sc .)
+{
+  echo "changed_files<<EOF"
+  echo "$CHANGED_FILES"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+count=$(echo "$CHANGED_FILES" | jq 'length')
+if [ "$count" -gt 0 ]; then
+  echo "Asset changes detected"
+  echo "has_asset_changes=true" >> "$GITHUB_OUTPUT"
+else
+  echo "No asset changes detected — skipping asset deploy"
+  echo "has_asset_changes=false" >> "$GITHUB_OUTPUT"
+fi
+
+DELETED_FILES=$(git -c core.quotePath=false diff --name-only --diff-filter=D "$BASE_SHA" HEAD \
+  | { grep -E "(${ASSET_DIRS})/.*\.json$" || true; } | jq -R . | jq -sc .)
+{
+  echo "deleted_files<<EOF"
+  echo "$DELETED_FILES"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+echo "Deleted assets: $(echo "$DELETED_FILES" | jq 'length')"
+
+# ── Integration spec diff ─────────────────────────────────────────────────────
+CHANGED_SPECS=$(git -c core.quotePath=false diff --name-only --diff-filter=AM "$BASE_SHA" HEAD \
+  | { grep "${INTEGRATION_MODELS_DIR}/.*-latest\.json$" || true; } | jq -R . | jq -sc .)
+
+DELETED_SPECS=$(git -c core.quotePath=false diff --name-only --diff-filter=D "$BASE_SHA" HEAD \
+  | { grep "${INTEGRATION_MODELS_DIR}/.*-latest\.json$" || true; } | jq -R . | jq -sc .)
+{
+  echo "deleted_specs<<EOF"
+  echo "$DELETED_SPECS"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+echo "Deleted specs: $(echo "$DELETED_SPECS" | jq 'length')"
+
+# Use heredoc format — GitHub Actions rejects bare JSON arrays as output values
+{
+  echo "changed_specs<<EOF"
+  echo "$CHANGED_SPECS"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+count=$(echo "$CHANGED_SPECS" | jq 'length')
+if [ "$count" -gt 0 ]; then
+  echo "Found $count changed spec(s)"
+  echo "has_spec_changes=true" >> "$GITHUB_OUTPUT"
+else
+  echo "No integration spec changes detected — skipping integration deploy"
+  echo "has_spec_changes=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/diff.sh
+++ b/.github/scripts/diff.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_SHA="${BASE_SHA:-}"
+BASE_SHA=$(git log --pretty=format:'%P' -n 1 HEAD | awk '{print $1}')
 ASSET_DIRS="Studio Projects|Agent Projects|Automations|LCM Resource Models|Golden Configs"
 INTEGRATION_MODELS_DIR="OpenAPIs"
 

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,34 +1,10 @@
-name: Itential Asset & Integration Promotion
+name: Itential Asset & Integration Bootstrap Import
 
 on:
-  pull_request_target:
-    types: [closed]
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  diff:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    outputs:
-      has_asset_changes: ${{ steps.diff.outputs.has_asset_changes }}
-      changed_files: ${{ steps.diff.outputs.changed_files }}
-      has_spec_changes: ${{ steps.diff.outputs.has_spec_changes }}
-      changed_specs: ${{ steps.diff.outputs.changed_specs }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Find changed files
-        id: diff
-        run: bash .github/scripts/diff.sh
-
-
-  deploy-assets-production:
-    needs: [diff]
-    if: github.event.pull_request.merged == true && needs.diff.outputs.has_asset_changes == 'true'
+  bootstrap-assets:
     runs-on: ubuntu-latest
     environment: production
 
@@ -46,19 +22,16 @@ jobs:
       - name: Install asyncplatform
         run: pip install git+https://github.com/Itential/asyncplatform.git
 
-      - name: Deploy to Production
+      - name: Import all assets
         env:
           HOST: ${{ secrets.PLATFORM_HOST }}
           CLIENT_ID: ${{ secrets.PLATFORM_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.PLATFORM_CLIENT_SECRET }}
           PROJECT_MEMBERS: ${{ vars.PROJECT_MEMBERS }}
-          CHANGED_FILES: ${{ needs.diff.outputs.changed_files }}
         run: python .github/scripts/deploy.py Production
 
 
-  deploy-integrations-production:
-    needs: [diff]
-    if: github.event.pull_request.merged == true && needs.diff.outputs.has_spec_changes == 'true'
+  bootstrap-integrations:
     runs-on: ubuntu-latest
     environment: production
 
@@ -83,8 +56,19 @@ jobs:
           printf '[profile default]\nhost = %s\nport = 0\nuse_tls = true\nclient_id = %s\nclient_secret = %s\n' \
             "$HOST" "$CLIENT_ID" "$CLIENT_SECRET" > /tmp/ipctl.ini
 
+      - name: Find all integration specs
+        id: specs
+        run: |
+          CHANGED_SPECS=$(find . -type f -path "*/OpenAPIs/*-latest.json" | sed 's|^\./||' | jq -R . | jq -sc .)
+          echo "Found specs: $CHANGED_SPECS"
+          {
+            echo "changed_specs<<EOF"
+            echo "$CHANGED_SPECS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Import integration models
         env:
           IPCTL_CONFIG_FILE: /tmp/ipctl.ini
-          CHANGED_SPECS: ${{ needs.diff.outputs.changed_specs }}
+          CHANGED_SPECS: ${{ steps.specs.outputs.changed_specs }}
         run: bash .github/scripts/deploy_integrations.sh

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -1,0 +1,93 @@
+name: Itential Asset & Integration Promotion
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    outputs:
+      has_asset_changes: ${{ steps.diff.outputs.has_asset_changes }}
+      changed_files: ${{ steps.diff.outputs.changed_files }}
+      has_spec_changes: ${{ steps.diff.outputs.has_spec_changes }}
+      changed_specs: ${{ steps.diff.outputs.changed_specs }}
+      deleted_files: ${{ steps.diff.outputs.deleted_files }}
+      deleted_specs: ${{ steps.diff.outputs.deleted_specs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find changed files
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash .github/scripts/diff.sh
+
+
+  deploy-assets-production:
+    needs: [diff]
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop' && needs.diff.outputs.has_asset_changes == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install asyncplatform
+        run: pip install git+https://github.com/Itential/asyncplatform.git
+
+      - name: Deploy to Production
+        env:
+          HOST: ${{ secrets.PLATFORM_HOST }}
+          CLIENT_ID: ${{ secrets.PLATFORM_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.PLATFORM_CLIENT_SECRET }}
+          PROJECT_MEMBERS: ${{ vars.PROJECT_MEMBERS }}
+          CHANGED_FILES: ${{ needs.diff.outputs.changed_files }}
+        run: python .github/scripts/deploy.py Production
+
+
+  deploy-integrations-production:
+    needs: [diff]
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop' && needs.diff.outputs.has_spec_changes == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ipctl
+        run: |
+          curl -LO "https://github.com/itential/ipctl/releases/latest/download/ipctl-linux-x86_64.tar.gz"
+          tar -xzf ipctl-linux-x86_64.tar.gz
+          sudo mv ipctl /usr/local/bin/
+
+      - name: Configure ipctl
+        env:
+          HOST: ${{ secrets.PLATFORM_HOST }}
+          CLIENT_ID: ${{ secrets.PLATFORM_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.PLATFORM_CLIENT_SECRET }}
+        run: |
+          printf '[profile default]\nhost = %s\nport = 0\nuse_tls = true\nclient_id = %s\nclient_secret = %s\n' \
+            "$HOST" "$CLIENT_ID" "$CLIENT_SECRET" > /tmp/ipctl.ini
+
+      - name: Import integration models
+        env:
+          IPCTL_CONFIG_FILE: /tmp/ipctl.ini
+          CHANGED_SPECS: ${{ needs.diff.outputs.changed_specs }}
+        run: bash .github/scripts/deploy_integrations.sh

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   diff:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel'
     runs-on: ubuntu-latest
     outputs:
       has_asset_changes: ${{ steps.diff.outputs.has_asset_changes }}
@@ -31,7 +32,7 @@ jobs:
 
   deploy-assets-production:
     needs: [diff]
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel' && needs.diff.outputs.has_asset_changes == 'true'
+    if: needs.diff.outputs.has_asset_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 
@@ -61,7 +62,7 @@ jobs:
 
   deploy-integrations-production:
     needs: [diff]
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel' && needs.diff.outputs.has_spec_changes == 'true'
+    if: needs.diff.outputs.has_spec_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -1,14 +1,14 @@
 name: Itential Asset & Integration Promotion
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main
 
 jobs:
   diff:
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       has_asset_changes: ${{ steps.diff.outputs.has_asset_changes }}
@@ -25,14 +25,12 @@ jobs:
 
       - name: Find changed files
         id: diff
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash .github/scripts/diff.sh
 
 
   deploy-assets-production:
     needs: [diff]
-    if: needs.diff.outputs.has_asset_changes == 'true'
+    if: github.event.pull_request.merged == true && needs.diff.outputs.has_asset_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 
@@ -62,7 +60,7 @@ jobs:
 
   deploy-integrations-production:
     needs: [diff]
-    if: needs.diff.outputs.has_spec_changes == 'true'
+    if: github.event.pull_request.merged == true && needs.diff.outputs.has_spec_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -31,7 +31,7 @@ jobs:
 
   deploy-assets-production:
     needs: [diff]
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop' && needs.diff.outputs.has_asset_changes == 'true'
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel' && needs.diff.outputs.has_asset_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 
@@ -61,7 +61,7 @@ jobs:
 
   deploy-integrations-production:
     needs: [diff]
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop' && needs.diff.outputs.has_spec_changes == 'true'
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'devel' && needs.diff.outputs.has_spec_changes == 'true'
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
This PR adds a GitHub pipeline that has multiple features:

- Diff logic to prevent unnecessary imports
- Runs on PR merge from any branch (fork or on assets repo) to main branch
- Deploys both integrations and all other assets, with detailed logs in the actions tab to monitor progress
  - only integrations that have -latest in their filename (intended to work with prebuilt projects in the repo) are imported, other integrations are ignored
- Pipeline imports all assets even if import fails, allowing for a follow-up PR to be made to fix any spec issues without messing up diff logic / user flow
- Github vars are used for pipeline secrets, to keep the burden of authentication on the configuration of the assets repo
  - Contributors will not need a service profile to the cloud env to contribute, only for their PR to be reviewed and approved