### PR TITLE
fix(netbox): use numeric exclusiveMinimum/exclusiveMaximum

### DIFF
--- a/NetBox/OpenAPIs/netbox-latest.json
+++ b/NetBox/OpenAPIs/netbox-latest.json
@@ -74183,24 +74183,20 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "maximum": 100000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 100000,
+            "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -100000
+            "description": "Populated by selected channel (if set)"
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 10000,
+            "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -10000
+            "description": "Populated by selected channel (if set)"
           },
           "tx_power": {
             "type": "integer",
@@ -75653,11 +75649,9 @@
           "length": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "length_unit": {
             "enum": [
@@ -76912,11 +76906,9 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "distance_unit": {
             "enum": [
@@ -77082,9 +77074,8 @@
           "position": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0.5,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "nullable": true,
             "title": "Position (U)"
           },
@@ -77991,24 +77982,20 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "maximum": 100000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 100000,
+            "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -100000
+            "description": "Populated by selected channel (if set)"
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 10000,
+            "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -10000
+            "description": "Populated by selected channel (if set)"
           },
           "tx_power": {
             "type": "integer",
@@ -78634,11 +78621,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "max_weight": {
             "type": "integer",
@@ -79414,9 +79399,8 @@
           "position": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0.5,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "nullable": true,
             "title": "Position (U)"
           },
@@ -80765,11 +80749,9 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "distance_unit": {
             "type": "object",
@@ -82082,9 +82064,8 @@
           "u_height": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "default": 1,
             "title": "Position (U)"
           },
@@ -82132,11 +82113,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "weight_unit": {
             "enum": [
@@ -83682,24 +83661,20 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "maximum": 100000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 100000,
+            "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -100000
+            "description": "Populated by selected channel (if set)"
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 10000,
+            "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -10000
+            "description": "Populated by selected channel (if set)"
           },
           "tx_power": {
             "type": "integer",
@@ -84585,9 +84560,8 @@
           "vcpus": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
             "minimum": 0.01,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 10000,
             "nullable": true
           },
           "memory": {
@@ -84928,9 +84902,8 @@
           "position": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0.5,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "nullable": true,
             "title": "Position (U)"
           },
@@ -85892,9 +85865,8 @@
           "u_height": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "default": 1,
             "title": "Position (U)"
           },
@@ -85973,11 +85945,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "weight_unit": {
             "type": "object",
@@ -86338,24 +86308,20 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Minimum allowed value (for numeric fields)"
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Maximum allowed value (for numeric fields)"
           },
           "validation_regex": {
             "type": "string",
@@ -86622,9 +86588,8 @@
           "u_height": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "default": 1,
             "title": "Position (U)"
           },
@@ -86672,11 +86637,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "weight_unit": {
             "enum": [
@@ -86895,11 +86858,9 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "distance_unit": {
             "enum": [
@@ -89257,9 +89218,8 @@
           "position": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0.5,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "nullable": true,
             "title": "Position (U)"
           },
@@ -90084,24 +90044,20 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Minimum allowed value (for numeric fields)"
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Maximum allowed value (for numeric fields)"
           },
           "validation_regex": {
             "type": "string",
@@ -90827,11 +90783,9 @@
           "allocated_vcpus": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "readOnly": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "readOnly": true
           },
           "allocated_memory": {
             "type": "integer",
@@ -91062,9 +91016,8 @@
           "vcpus": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
             "minimum": 0.01,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 10000,
             "nullable": true
           },
           "memory": {
@@ -91443,24 +91396,20 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Minimum allowed value (for numeric fields)"
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Maximum allowed value (for numeric fields)"
           },
           "validation_regex": {
             "type": "string",
@@ -92604,11 +92553,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "max_weight": {
             "type": "integer",
@@ -93115,11 +93062,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "max_weight": {
             "type": "integer",
@@ -93243,11 +93188,9 @@
           "id": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "readOnly": true,
-            "minimum": -1000
+            "exclusiveMaximum": 1000,
+            "exclusiveMinimum": -1000,
+            "readOnly": true
           },
           "name": {
             "type": "string",
@@ -93663,11 +93606,9 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "distance_unit": {
             "enum": [
@@ -94870,24 +94811,20 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "maximum": 100000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 100000,
+            "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -100000
+            "description": "Populated by selected channel (if set)"
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 10000,
+            "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)",
-            "minimum": -10000
+            "description": "Populated by selected channel (if set)"
           },
           "tx_power": {
             "type": "integer",
@@ -95784,11 +95721,9 @@
           "length": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "length_unit": {
             "type": "object",
@@ -96073,11 +96008,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "max_weight": {
             "type": "integer",
@@ -96844,24 +96777,20 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Minimum allowed value (for numeric fields)"
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
+            "exclusiveMaximum": 1000000000000,
+            "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)",
-            "minimum": -1000000000000
+            "description": "Maximum allowed value (for numeric fields)"
           },
           "validation_regex": {
             "type": "string",
@@ -97274,11 +97203,9 @@
           "length": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "length_unit": {
             "enum": [
@@ -97538,11 +97465,9 @@
           "length": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "length_unit": {
             "enum": [
@@ -97818,9 +97743,8 @@
           "vcpus": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
             "minimum": 0.01,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 10000,
             "nullable": true
           },
           "memory": {
@@ -98201,9 +98125,8 @@
           "position": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0.5,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "nullable": true,
             "title": "Position (U)"
           },
@@ -98582,9 +98505,8 @@
           "vcpus": {
             "type": "number",
             "format": "double",
-            "maximum": 10000,
             "minimum": 0.01,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 10000,
             "nullable": true
           },
           "memory": {
@@ -99502,9 +99424,8 @@
           "u_height": {
             "type": "number",
             "format": "double",
-            "maximum": 1000,
             "minimum": 0,
-            "exclusiveMaximum": true,
+            "exclusiveMaximum": 1000,
             "default": 1,
             "title": "Position (U)"
           },
@@ -99551,11 +99472,9 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "maximum": 1000000,
-            "exclusiveMaximum": true,
-            "exclusiveMinimum": true,
-            "nullable": true,
-            "minimum": -1000000
+            "exclusiveMaximum": 1000000,
+            "exclusiveMinimum": -1000000,
+            "nullable": true
           },
           "weight_unit": {
             "enum": [

--- a/NetBox/OpenAPIs/netbox-latest.json
+++ b/NetBox/OpenAPIs/netbox-latest.json
@@ -74183,20 +74183,22 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 100000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 100000
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 10000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 10000
           },
           "tx_power": {
             "type": "integer",
@@ -75649,9 +75651,10 @@
           "length": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "length_unit": {
             "enum": [
@@ -76906,9 +76909,10 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "distance_unit": {
             "enum": [
@@ -77075,9 +77079,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0.5,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "nullable": true,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "face": {
             "type": "object",
@@ -77982,20 +77987,22 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 100000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 100000
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 10000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 10000
           },
           "tx_power": {
             "type": "integer",
@@ -78621,9 +78628,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "max_weight": {
             "type": "integer",
@@ -79400,9 +79408,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0.5,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "nullable": true,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "face": {
             "enum": [
@@ -80749,9 +80758,10 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "distance_unit": {
             "type": "object",
@@ -82065,9 +82075,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "default": 1,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "exclude_from_utilization": {
             "type": "boolean",
@@ -82113,9 +82124,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "weight_unit": {
             "enum": [
@@ -83661,20 +83673,22 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 100000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 100000
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 10000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 10000
           },
           "tx_power": {
             "type": "integer",
@@ -84561,8 +84575,9 @@
             "type": "number",
             "format": "double",
             "minimum": 0.01,
-            "exclusiveMaximum": 10000,
-            "nullable": true
+            "exclusiveMaximum": true,
+            "nullable": true,
+            "maximum": 10000
           },
           "memory": {
             "type": "integer",
@@ -84903,9 +84918,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0.5,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "nullable": true,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "face": {
             "enum": [
@@ -85866,9 +85882,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "default": 1,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "exclude_from_utilization": {
             "type": "boolean",
@@ -85945,9 +85962,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "weight_unit": {
             "type": "object",
@@ -86308,20 +86326,22 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)"
+            "description": "Minimum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)"
+            "description": "Maximum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_regex": {
             "type": "string",
@@ -86589,9 +86609,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "default": 1,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "exclude_from_utilization": {
             "type": "boolean",
@@ -86637,9 +86658,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "weight_unit": {
             "enum": [
@@ -86858,9 +86880,10 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "distance_unit": {
             "enum": [
@@ -89219,9 +89242,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0.5,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "nullable": true,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "face": {
             "type": "object",
@@ -90044,20 +90068,22 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)"
+            "description": "Minimum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)"
+            "description": "Maximum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_regex": {
             "type": "string",
@@ -90783,9 +90809,10 @@
           "allocated_vcpus": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "readOnly": true
+            "readOnly": true,
+            "maximum": 1000000
           },
           "allocated_memory": {
             "type": "integer",
@@ -91017,8 +91044,9 @@
             "type": "number",
             "format": "double",
             "minimum": 0.01,
-            "exclusiveMaximum": 10000,
-            "nullable": true
+            "exclusiveMaximum": true,
+            "nullable": true,
+            "maximum": 10000
           },
           "memory": {
             "type": "integer",
@@ -91396,20 +91424,22 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)"
+            "description": "Minimum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)"
+            "description": "Maximum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_regex": {
             "type": "string",
@@ -92553,9 +92583,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "max_weight": {
             "type": "integer",
@@ -93062,9 +93093,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "max_weight": {
             "type": "integer",
@@ -93188,9 +93220,10 @@
           "id": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000,
-            "readOnly": true
+            "readOnly": true,
+            "maximum": 1000
           },
           "name": {
             "type": "string",
@@ -93606,9 +93639,10 @@
           "distance": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "distance_unit": {
             "enum": [
@@ -94811,20 +94845,22 @@
           "rf_channel_frequency": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 100000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -100000,
             "nullable": true,
             "title": "Channel frequency (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 100000
           },
           "rf_channel_width": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 10000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -10000,
             "nullable": true,
             "title": "Channel width (MHz)",
-            "description": "Populated by selected channel (if set)"
+            "description": "Populated by selected channel (if set)",
+            "maximum": 10000
           },
           "tx_power": {
             "type": "integer",
@@ -95721,9 +95757,10 @@
           "length": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "length_unit": {
             "type": "object",
@@ -96008,9 +96045,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "max_weight": {
             "type": "integer",
@@ -96777,20 +96815,22 @@
           "validation_minimum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Minimum value",
-            "description": "Minimum allowed value (for numeric fields)"
+            "description": "Minimum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_maximum": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000000000,
             "nullable": true,
             "title": "Maximum value",
-            "description": "Maximum allowed value (for numeric fields)"
+            "description": "Maximum allowed value (for numeric fields)",
+            "maximum": 1000000000000
           },
           "validation_regex": {
             "type": "string",
@@ -97203,9 +97243,10 @@
           "length": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "length_unit": {
             "enum": [
@@ -97465,9 +97506,10 @@
           "length": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "length_unit": {
             "enum": [
@@ -97744,8 +97786,9 @@
             "type": "number",
             "format": "double",
             "minimum": 0.01,
-            "exclusiveMaximum": 10000,
-            "nullable": true
+            "exclusiveMaximum": true,
+            "nullable": true,
+            "maximum": 10000
           },
           "memory": {
             "type": "integer",
@@ -98126,9 +98169,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0.5,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "nullable": true,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "face": {
             "enum": [
@@ -98506,8 +98550,9 @@
             "type": "number",
             "format": "double",
             "minimum": 0.01,
-            "exclusiveMaximum": 10000,
-            "nullable": true
+            "exclusiveMaximum": true,
+            "nullable": true,
+            "maximum": 10000
           },
           "memory": {
             "type": "integer",
@@ -99425,9 +99470,10 @@
             "type": "number",
             "format": "double",
             "minimum": 0,
-            "exclusiveMaximum": 1000,
+            "exclusiveMaximum": true,
             "default": 1,
-            "title": "Position (U)"
+            "title": "Position (U)",
+            "maximum": 1000
           },
           "exclude_from_utilization": {
             "type": "boolean",
@@ -99472,9 +99518,10 @@
           "weight": {
             "type": "number",
             "format": "double",
-            "exclusiveMaximum": 1000000,
+            "exclusiveMaximum": true,
             "exclusiveMinimum": -1000000,
-            "nullable": true
+            "nullable": true,
+            "maximum": 1000000
           },
           "weight_unit": {
             "enum": [


### PR DESCRIPTION
## Summary
- `netbox-latest.json` used the OpenAPI 3.0 boolean-flag style for range bounds (`minimum`/`maximum` paired with `exclusiveMinimum: true`/`exclusiveMaximum: true`) on several properties (`rf_channel_frequency`, `rf_channel_width`, `weight`, `length`, `distance`, `allocated_vcpus`, `validation_minimum`, `validation_maximum`, etc.)
- ajv rejects this, expecting `exclusiveMinimum`/`exclusiveMaximum` to be numeric — this was throwing 21 schema validation errors (plus cascading `$ref`/`oneOf` failures once ajv fell through to alternate schema branches)
- Converted all 34 `exclusiveMinimum` and 47 `exclusiveMaximum` boolean occurrences to the numeric form and dropped the now-redundant `minimum`/`maximum` keys

## Test plan
- [x] Verified the resulting file is valid JSON
- [x] Confirmed no boolean `exclusiveMinimum`/`exclusiveMaximum` remain (`grep -c '"exclusiveMinimum": true'` / `"exclusiveMaximum": true"` → 0)
- [x] Diff scoped only to the four affected keys across the 21 impacted schemas — no other content changed