### PR TITLE
fix(netbox): correct security scheme reference to tokenAuth

### DIFF
--- a/NetBox/OpenAPIs/netbox-latest.json
+++ b/NetBox/OpenAPIs/netbox-latest.json
@@ -21,7 +21,7 @@
   ],
   "security": [
     {
-      "bearerAuth": []
+      "tokenAuth": []
     }
   ],
   "paths": {
@@ -1899,7 +1899,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -1958,7 +1958,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2003,7 +2003,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2051,7 +2051,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2099,7 +2099,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2129,7 +2129,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2179,7 +2179,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2228,7 +2228,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2263,7 +2263,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -2293,7 +2293,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3414,7 +3414,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3473,7 +3473,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3518,7 +3518,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3566,7 +3566,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3614,7 +3614,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3644,7 +3644,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3694,7 +3694,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3743,7 +3743,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -3778,7 +3778,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -5846,7 +5846,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -5905,7 +5905,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -5950,7 +5950,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -5998,7 +5998,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -6046,7 +6046,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -6076,7 +6076,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -6126,7 +6126,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -6175,7 +6175,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -6210,7 +6210,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7455,7 +7455,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7514,7 +7514,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7559,7 +7559,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7607,7 +7607,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7655,7 +7655,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7685,7 +7685,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7735,7 +7735,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7784,7 +7784,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -7819,7 +7819,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -9988,7 +9988,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10046,7 +10046,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10091,7 +10091,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10139,7 +10139,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10187,7 +10187,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10217,7 +10217,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10266,7 +10266,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10315,7 +10315,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10350,7 +10350,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -10389,7 +10389,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11650,7 +11650,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11709,7 +11709,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11754,7 +11754,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11802,7 +11802,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11850,7 +11850,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11880,7 +11880,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11930,7 +11930,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -11979,7 +11979,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -12014,7 +12014,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -14928,7 +14928,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -14987,7 +14987,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15032,7 +15032,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15080,7 +15080,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15128,7 +15128,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15158,7 +15158,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15208,7 +15208,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15257,7 +15257,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -15292,7 +15292,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19374,7 +19374,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19433,7 +19433,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19478,7 +19478,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19526,7 +19526,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19574,7 +19574,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19604,7 +19604,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19654,7 +19654,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19703,7 +19703,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19738,7 +19738,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -19794,7 +19794,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24317,7 +24317,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24376,7 +24376,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24421,7 +24421,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24469,7 +24469,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24517,7 +24517,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24547,7 +24547,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24597,7 +24597,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24646,7 +24646,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24681,7 +24681,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -24711,7 +24711,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26423,7 +26423,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26482,7 +26482,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26527,7 +26527,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26575,7 +26575,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26623,7 +26623,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26653,7 +26653,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26703,7 +26703,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26752,7 +26752,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -26787,7 +26787,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -27871,7 +27871,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -27930,7 +27930,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -27975,7 +27975,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28023,7 +28023,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28071,7 +28071,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28101,7 +28101,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28151,7 +28151,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28200,7 +28200,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -28235,7 +28235,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29274,7 +29274,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29333,7 +29333,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29378,7 +29378,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29426,7 +29426,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29474,7 +29474,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29504,7 +29504,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29554,7 +29554,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29603,7 +29603,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -29638,7 +29638,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -30790,7 +30790,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -30849,7 +30849,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -30894,7 +30894,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -30942,7 +30942,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -30990,7 +30990,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -31020,7 +31020,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -31070,7 +31070,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -31119,7 +31119,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -31154,7 +31154,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34675,7 +34675,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34734,7 +34734,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34779,7 +34779,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34827,7 +34827,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34875,7 +34875,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34905,7 +34905,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -34955,7 +34955,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -35004,7 +35004,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -35039,7 +35039,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -35187,7 +35187,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36335,7 +36335,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36394,7 +36394,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36439,7 +36439,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36487,7 +36487,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36535,7 +36535,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36565,7 +36565,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36615,7 +36615,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36664,7 +36664,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -36699,7 +36699,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -37840,7 +37840,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -37899,7 +37899,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -37944,7 +37944,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -37992,7 +37992,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -38040,7 +38040,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -38070,7 +38070,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -38120,7 +38120,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -38169,7 +38169,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -38204,7 +38204,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40127,7 +40127,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40186,7 +40186,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40231,7 +40231,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40279,7 +40279,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40327,7 +40327,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40357,7 +40357,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40407,7 +40407,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40456,7 +40456,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -40491,7 +40491,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -42981,7 +42981,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43040,7 +43040,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43085,7 +43085,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43133,7 +43133,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43181,7 +43181,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43211,7 +43211,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43261,7 +43261,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43310,7 +43310,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -43345,7 +43345,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44558,7 +44558,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44617,7 +44617,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44662,7 +44662,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44710,7 +44710,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44758,7 +44758,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44788,7 +44788,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44838,7 +44838,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44887,7 +44887,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -44922,7 +44922,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -45913,7 +45913,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -45972,7 +45972,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46017,7 +46017,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46065,7 +46065,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46113,7 +46113,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46143,7 +46143,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46193,7 +46193,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46242,7 +46242,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -46277,7 +46277,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48116,7 +48116,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48175,7 +48175,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48220,7 +48220,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48268,7 +48268,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48316,7 +48316,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48346,7 +48346,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48396,7 +48396,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48445,7 +48445,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -48480,7 +48480,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49756,7 +49756,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49815,7 +49815,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49860,7 +49860,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49908,7 +49908,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49956,7 +49956,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -49986,7 +49986,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -50036,7 +50036,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -50085,7 +50085,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -50120,7 +50120,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -50149,7 +50149,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -50207,7 +50207,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52064,7 +52064,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52123,7 +52123,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52168,7 +52168,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52216,7 +52216,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52264,7 +52264,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52294,7 +52294,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52344,7 +52344,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52393,7 +52393,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52428,7 +52428,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52457,7 +52457,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52515,7 +52515,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52554,7 +52554,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -52612,7 +52612,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53592,7 +53592,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53651,7 +53651,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53696,7 +53696,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53744,7 +53744,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53792,7 +53792,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53822,7 +53822,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53872,7 +53872,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53921,7 +53921,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -53956,7 +53956,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55004,7 +55004,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55063,7 +55063,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55108,7 +55108,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55156,7 +55156,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55204,7 +55204,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55234,7 +55234,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55284,7 +55284,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55333,7 +55333,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -55368,7 +55368,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56690,7 +56690,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56749,7 +56749,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56794,7 +56794,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56842,7 +56842,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56890,7 +56890,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56920,7 +56920,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -56970,7 +56970,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -57019,7 +57019,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -57054,7 +57054,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -57083,7 +57083,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -57141,7 +57141,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -58996,7 +58996,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59055,7 +59055,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59100,7 +59100,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59148,7 +59148,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59196,7 +59196,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59226,7 +59226,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59276,7 +59276,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59325,7 +59325,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -59360,7 +59360,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60536,7 +60536,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60595,7 +60595,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60640,7 +60640,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60688,7 +60688,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60736,7 +60736,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60766,7 +60766,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60816,7 +60816,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60865,7 +60865,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -60900,7 +60900,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -61965,7 +61965,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62024,7 +62024,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62069,7 +62069,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62117,7 +62117,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62165,7 +62165,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62195,7 +62195,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62245,7 +62245,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62294,7 +62294,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -62329,7 +62329,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63416,7 +63416,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63475,7 +63475,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63520,7 +63520,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63568,7 +63568,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63616,7 +63616,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63646,7 +63646,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63696,7 +63696,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63745,7 +63745,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -63780,7 +63780,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -64819,7 +64819,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -64878,7 +64878,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -64923,7 +64923,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -64971,7 +64971,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -65019,7 +65019,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -65049,7 +65049,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -65099,7 +65099,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -65148,7 +65148,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -65183,7 +65183,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66146,7 +66146,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66205,7 +66205,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66250,7 +66250,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66298,7 +66298,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66346,7 +66346,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66376,7 +66376,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66426,7 +66426,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66475,7 +66475,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -66510,7 +66510,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68074,7 +68074,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68133,7 +68133,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68178,7 +68178,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68226,7 +68226,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68274,7 +68274,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68304,7 +68304,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68354,7 +68354,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68403,7 +68403,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -68438,7 +68438,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70066,7 +70066,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70125,7 +70125,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70170,7 +70170,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70218,7 +70218,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70266,7 +70266,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70296,7 +70296,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70346,7 +70346,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70395,7 +70395,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -70430,7 +70430,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73130,7 +73130,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73189,7 +73189,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73234,7 +73234,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73282,7 +73282,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73330,7 +73330,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73360,7 +73360,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73410,7 +73410,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73459,7 +73459,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73494,7 +73494,7 @@
         ],
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -73550,7 +73550,7 @@
         },
         "security": [
           {
-            "bearerAuth": []
+            "tokenAuth": []
           }
         ],
         "responses": {
@@ -99884,7 +99884,7 @@
       }
     },
     "securitySchemes": {
-      "bearerAuth": {
+      "tokenAuth": {
         "type": "apiKey",
         "in": "header",
         "name": "Authorization",


### PR DESCRIPTION
## Summary
- The NetBox OpenAPI spec's `security` blocks referenced a scheme named `bearerAuth`, but the scheme should be defined as `tokenAuth`

## Test plan
- [x] Re-import `netbox-latest.json` as an Integration Model and confirm connectivity to Netbox lab env