### PR TITLE
fix(netbox): correct security scheme naming and servers/paths structure

### DIFF
--- a/NetBox/OpenAPIs/netbox-3.7.8.json
+++ b/NetBox/OpenAPIs/netbox-3.7.8.json
@@ -11,7 +11,7 @@
     }
   ],
   "paths": {
-    "/circuits/circuit-terminations/": {
+    "/api/circuits/circuit-terminations/": {
       "get": {
         "operationId": "circuits_circuit-terminations_list",
         "description": "",
@@ -804,7 +804,7 @@
       },
       "parameters": []
     },
-    "/circuits/circuit-terminations/{id}/": {
+    "/api/circuits/circuit-terminations/{id}/": {
       "get": {
         "operationId": "circuits_circuit-terminations_read",
         "description": "",
@@ -892,7 +892,7 @@
         }
       ]
     },
-    "/circuits/circuit-terminations/{id}/paths/": {
+    "/api/circuits/circuit-terminations/{id}/paths/": {
       "get": {
         "operationId": "circuits_circuit-terminations_paths",
         "description": "Return all CablePaths which traverse a given pass-through port.",
@@ -924,7 +924,7 @@
         }
       ]
     },
-    "/circuits/circuit-types/": {
+    "/api/circuits/circuit-types/": {
       "get": {
         "operationId": "circuits_circuit-types_list",
         "description": "",
@@ -1582,7 +1582,7 @@
       },
       "parameters": []
     },
-    "/circuits/circuit-types/{id}/": {
+    "/api/circuits/circuit-types/{id}/": {
       "get": {
         "operationId": "circuits_circuit-types_read",
         "description": "",
@@ -1670,7 +1670,7 @@
         }
       ]
     },
-    "/circuits/circuits/": {
+    "/api/circuits/circuits/": {
       "get": {
         "operationId": "circuits_circuits_list",
         "description": "",
@@ -2751,7 +2751,7 @@
       },
       "parameters": []
     },
-    "/circuits/circuits/{id}/": {
+    "/api/circuits/circuits/{id}/": {
       "get": {
         "operationId": "circuits_circuits_read",
         "description": "",
@@ -2839,7 +2839,7 @@
         }
       ]
     },
-    "/circuits/provider-accounts/": {
+    "/api/circuits/provider-accounts/": {
       "get": {
         "operationId": "circuits_provider-accounts_list",
         "description": "",
@@ -3533,7 +3533,7 @@
       },
       "parameters": []
     },
-    "/circuits/provider-accounts/{id}/": {
+    "/api/circuits/provider-accounts/{id}/": {
       "get": {
         "operationId": "circuits_provider-accounts_read",
         "description": "",
@@ -3621,7 +3621,7 @@
         }
       ]
     },
-    "/circuits/provider-networks/": {
+    "/api/circuits/provider-networks/": {
       "get": {
         "operationId": "circuits_provider-networks_list",
         "description": "",
@@ -4315,7 +4315,7 @@
       },
       "parameters": []
     },
-    "/circuits/provider-networks/{id}/": {
+    "/api/circuits/provider-networks/{id}/": {
       "get": {
         "operationId": "circuits_provider-networks_read",
         "description": "",
@@ -4403,7 +4403,7 @@
         }
       ]
     },
-    "/circuits/providers/": {
+    "/api/circuits/providers/": {
       "get": {
         "operationId": "circuits_providers_list",
         "description": "",
@@ -5142,7 +5142,7 @@
       },
       "parameters": []
     },
-    "/circuits/providers/{id}/": {
+    "/api/circuits/providers/{id}/": {
       "get": {
         "operationId": "circuits_providers_read",
         "description": "",
@@ -5230,7 +5230,7 @@
         }
       ]
     },
-    "/core/data-files/": {
+    "/api/core/data-files/": {
       "get": {
         "operationId": "core_data-files_list",
         "description": "",
@@ -5783,7 +5783,7 @@
       },
       "parameters": []
     },
-    "/core/data-files/{id}/": {
+    "/api/core/data-files/{id}/": {
       "get": {
         "operationId": "core_data-files_read",
         "description": "",
@@ -5815,7 +5815,7 @@
         }
       ]
     },
-    "/core/data-sources/": {
+    "/api/core/data-sources/": {
       "get": {
         "operationId": "core_data-sources_list",
         "description": "",
@@ -6320,7 +6320,7 @@
       },
       "parameters": []
     },
-    "/core/data-sources/{id}/": {
+    "/api/core/data-sources/{id}/": {
       "get": {
         "operationId": "core_data-sources_read",
         "description": "",
@@ -6408,7 +6408,7 @@
         }
       ]
     },
-    "/core/data-sources/{id}/sync/": {
+    "/api/core/data-sources/{id}/sync/": {
       "post": {
         "operationId": "core_data-sources_sync",
         "description": "Enqueue a job to synchronize the DataSource.",
@@ -6443,7 +6443,7 @@
         }
       ]
     },
-    "/core/jobs/": {
+    "/api/core/jobs/": {
       "get": {
         "operationId": "core_jobs_list",
         "description": "Retrieve a list of job results",
@@ -6951,7 +6951,7 @@
       },
       "parameters": []
     },
-    "/core/jobs/{id}/": {
+    "/api/core/jobs/{id}/": {
       "get": {
         "operationId": "core_jobs_read",
         "description": "Retrieve a list of job results",
@@ -6983,7 +6983,7 @@
         }
       ]
     },
-    "/dcim/cable-terminations/": {
+    "/api/dcim/cable-terminations/": {
       "get": {
         "operationId": "dcim_cable-terminations_list",
         "description": "",
@@ -7299,7 +7299,7 @@
       },
       "parameters": []
     },
-    "/dcim/cable-terminations/{id}/": {
+    "/api/dcim/cable-terminations/{id}/": {
       "get": {
         "operationId": "dcim_cable-terminations_read",
         "description": "",
@@ -7387,7 +7387,7 @@
         }
       ]
     },
-    "/dcim/cables/": {
+    "/api/dcim/cables/": {
       "get": {
         "operationId": "dcim_cables_list",
         "description": "",
@@ -8261,7 +8261,7 @@
       },
       "parameters": []
     },
-    "/dcim/cables/{id}/": {
+    "/api/dcim/cables/{id}/": {
       "get": {
         "operationId": "dcim_cables_read",
         "description": "",
@@ -8349,7 +8349,7 @@
         }
       ]
     },
-    "/dcim/connected-device/": {
+    "/api/dcim/connected-device/": {
       "get": {
         "operationId": "dcim_connected-device_list",
         "description": "This endpoint allows a user to determine what device (if any) is connected to a given peer device and peer\ninterface. This is useful in a situation where a device boots with no configuration, but can detect its neighbors\nvia a protocol such as LLDP. Two query parameters must be included in the request:\n\n* `peer_device`: The name of the peer device\n* `peer_interface`: The name of the peer interface",
@@ -8391,7 +8391,7 @@
       },
       "parameters": []
     },
-    "/dcim/console-port-templates/": {
+    "/api/dcim/console-port-templates/": {
       "get": {
         "operationId": "dcim_console-port-templates_list",
         "description": "",
@@ -8887,7 +8887,7 @@
       },
       "parameters": []
     },
-    "/dcim/console-port-templates/{id}/": {
+    "/api/dcim/console-port-templates/{id}/": {
       "get": {
         "operationId": "dcim_console-port-templates_read",
         "description": "",
@@ -8975,7 +8975,7 @@
         }
       ]
     },
-    "/dcim/console-ports/": {
+    "/api/dcim/console-ports/": {
       "get": {
         "operationId": "dcim_console-ports_list",
         "description": "",
@@ -9966,7 +9966,7 @@
       },
       "parameters": []
     },
-    "/dcim/console-ports/{id}/": {
+    "/api/dcim/console-ports/{id}/": {
       "get": {
         "operationId": "dcim_console-ports_read",
         "description": "",
@@ -10054,7 +10054,7 @@
         }
       ]
     },
-    "/dcim/console-ports/{id}/trace/": {
+    "/api/dcim/console-ports/{id}/trace/": {
       "get": {
         "operationId": "dcim_console-ports_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -10086,7 +10086,7 @@
         }
       ]
     },
-    "/dcim/console-server-port-templates/": {
+    "/api/dcim/console-server-port-templates/": {
       "get": {
         "operationId": "dcim_console-server-port-templates_list",
         "description": "",
@@ -10582,7 +10582,7 @@
       },
       "parameters": []
     },
-    "/dcim/console-server-port-templates/{id}/": {
+    "/api/dcim/console-server-port-templates/{id}/": {
       "get": {
         "operationId": "dcim_console-server-port-templates_read",
         "description": "",
@@ -10670,7 +10670,7 @@
         }
       ]
     },
-    "/dcim/console-server-ports/": {
+    "/api/dcim/console-server-ports/": {
       "get": {
         "operationId": "dcim_console-server-ports_list",
         "description": "",
@@ -11661,7 +11661,7 @@
       },
       "parameters": []
     },
-    "/dcim/console-server-ports/{id}/": {
+    "/api/dcim/console-server-ports/{id}/": {
       "get": {
         "operationId": "dcim_console-server-ports_read",
         "description": "",
@@ -11749,7 +11749,7 @@
         }
       ]
     },
-    "/dcim/console-server-ports/{id}/trace/": {
+    "/api/dcim/console-server-ports/{id}/trace/": {
       "get": {
         "operationId": "dcim_console-server-ports_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -11781,7 +11781,7 @@
         }
       ]
     },
-    "/dcim/device-bay-templates/": {
+    "/api/dcim/device-bay-templates/": {
       "get": {
         "operationId": "dcim_device-bay-templates_list",
         "description": "",
@@ -12241,7 +12241,7 @@
       },
       "parameters": []
     },
-    "/dcim/device-bay-templates/{id}/": {
+    "/api/dcim/device-bay-templates/{id}/": {
       "get": {
         "operationId": "dcim_device-bay-templates_read",
         "description": "",
@@ -12329,7 +12329,7 @@
         }
       ]
     },
-    "/dcim/device-bays/": {
+    "/api/dcim/device-bays/": {
       "get": {
         "operationId": "dcim_device-bays_list",
         "description": "",
@@ -13239,7 +13239,7 @@
       },
       "parameters": []
     },
-    "/dcim/device-bays/{id}/": {
+    "/api/dcim/device-bays/{id}/": {
       "get": {
         "operationId": "dcim_device-bays_read",
         "description": "",
@@ -13327,7 +13327,7 @@
         }
       ]
     },
-    "/dcim/device-roles/": {
+    "/api/dcim/device-roles/": {
       "get": {
         "operationId": "dcim_device-roles_list",
         "description": "",
@@ -14111,7 +14111,7 @@
       },
       "parameters": []
     },
-    "/dcim/device-roles/{id}/": {
+    "/api/dcim/device-roles/{id}/": {
       "get": {
         "operationId": "dcim_device-roles_read",
         "description": "",
@@ -14199,7 +14199,7 @@
         }
       ]
     },
-    "/dcim/device-types/": {
+    "/api/dcim/device-types/": {
       "get": {
         "operationId": "dcim_device-types_list",
         "description": "",
@@ -15199,7 +15199,7 @@
       },
       "parameters": []
     },
-    "/dcim/device-types/{id}/": {
+    "/api/dcim/device-types/{id}/": {
       "get": {
         "operationId": "dcim_device-types_read",
         "description": "",
@@ -15287,7 +15287,7 @@
         }
       ]
     },
-    "/dcim/devices/": {
+    "/api/dcim/devices/": {
       "get": {
         "operationId": "dcim_devices_list",
         "description": "",
@@ -16837,7 +16837,7 @@
       },
       "parameters": []
     },
-    "/dcim/devices/{id}/": {
+    "/api/dcim/devices/{id}/": {
       "get": {
         "operationId": "dcim_devices_read",
         "description": "",
@@ -16898,7 +16898,7 @@
         }
       ]
     },
-    "/dcim/devices/{id}/render-config/": {
+    "/api/dcim/devices/{id}/render-config/": {
       "post": {
         "operationId": "dcim_devices_render_config",
         "description": "Resolve and render the preferred ConfigTemplate for this Device.",
@@ -16923,7 +16923,7 @@
         }
       ]
     },
-    "/dcim/front-port-templates/": {
+    "/api/dcim/front-port-templates/": {
       "get": {
         "operationId": "dcim_front-port-templates_list",
         "description": "",
@@ -17518,7 +17518,7 @@
       },
       "parameters": []
     },
-    "/dcim/front-port-templates/{id}/": {
+    "/api/dcim/front-port-templates/{id}/": {
       "get": {
         "operationId": "dcim_front-port-templates_read",
         "description": "",
@@ -17606,7 +17606,7 @@
         }
       ]
     },
-    "/dcim/front-ports/": {
+    "/api/dcim/front-ports/": {
       "get": {
         "operationId": "dcim_front-ports_list",
         "description": "",
@@ -18687,7 +18687,7 @@
       },
       "parameters": []
     },
-    "/dcim/front-ports/{id}/": {
+    "/api/dcim/front-ports/{id}/": {
       "get": {
         "operationId": "dcim_front-ports_read",
         "description": "",
@@ -18775,7 +18775,7 @@
         }
       ]
     },
-    "/dcim/front-ports/{id}/paths/": {
+    "/api/dcim/front-ports/{id}/paths/": {
       "get": {
         "operationId": "dcim_front-ports_paths",
         "description": "Return all CablePaths which traverse a given pass-through port.",
@@ -18807,7 +18807,7 @@
         }
       ]
     },
-    "/dcim/interface-templates/": {
+    "/api/dcim/interface-templates/": {
       "get": {
         "operationId": "dcim_interface-templates_list",
         "description": "",
@@ -19375,7 +19375,7 @@
       },
       "parameters": []
     },
-    "/dcim/interface-templates/{id}/": {
+    "/api/dcim/interface-templates/{id}/": {
       "get": {
         "operationId": "dcim_interface-templates_read",
         "description": "",
@@ -19463,7 +19463,7 @@
         }
       ]
     },
-    "/dcim/interfaces/": {
+    "/api/dcim/interfaces/": {
       "get": {
         "operationId": "dcim_interfaces_list",
         "description": "",
@@ -21219,7 +21219,7 @@
       },
       "parameters": []
     },
-    "/dcim/interfaces/{id}/": {
+    "/api/dcim/interfaces/{id}/": {
       "get": {
         "operationId": "dcim_interfaces_read",
         "description": "",
@@ -21307,7 +21307,7 @@
         }
       ]
     },
-    "/dcim/interfaces/{id}/trace/": {
+    "/api/dcim/interfaces/{id}/trace/": {
       "get": {
         "operationId": "dcim_interfaces_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -21339,7 +21339,7 @@
         }
       ]
     },
-    "/dcim/inventory-item-roles/": {
+    "/api/dcim/inventory-item-roles/": {
       "get": {
         "operationId": "dcim_inventory-item-roles_list",
         "description": "",
@@ -21997,7 +21997,7 @@
       },
       "parameters": []
     },
-    "/dcim/inventory-item-roles/{id}/": {
+    "/api/dcim/inventory-item-roles/{id}/": {
       "get": {
         "operationId": "dcim_inventory-item-roles_read",
         "description": "",
@@ -22085,7 +22085,7 @@
         }
       ]
     },
-    "/dcim/inventory-item-templates/": {
+    "/api/dcim/inventory-item-templates/": {
       "get": {
         "operationId": "dcim_inventory-item-templates_list",
         "description": "",
@@ -22905,7 +22905,7 @@
       },
       "parameters": []
     },
-    "/dcim/inventory-item-templates/{id}/": {
+    "/api/dcim/inventory-item-templates/{id}/": {
       "get": {
         "operationId": "dcim_inventory-item-templates_read",
         "description": "",
@@ -22993,7 +22993,7 @@
         }
       ]
     },
-    "/dcim/inventory-items/": {
+    "/api/dcim/inventory-items/": {
       "get": {
         "operationId": "dcim_inventory-items_list",
         "description": "",
@@ -24272,7 +24272,7 @@
       },
       "parameters": []
     },
-    "/dcim/inventory-items/{id}/": {
+    "/api/dcim/inventory-items/{id}/": {
       "get": {
         "operationId": "dcim_inventory-items_read",
         "description": "",
@@ -24360,7 +24360,7 @@
         }
       ]
     },
-    "/dcim/locations/": {
+    "/api/dcim/locations/": {
       "get": {
         "operationId": "dcim_locations_list",
         "description": "",
@@ -25306,7 +25306,7 @@
       },
       "parameters": []
     },
-    "/dcim/locations/{id}/": {
+    "/api/dcim/locations/{id}/": {
       "get": {
         "operationId": "dcim_locations_read",
         "description": "",
@@ -25394,7 +25394,7 @@
         }
       ]
     },
-    "/dcim/manufacturers/": {
+    "/api/dcim/manufacturers/": {
       "get": {
         "operationId": "dcim_manufacturers_list",
         "description": "",
@@ -26106,7 +26106,7 @@
       },
       "parameters": []
     },
-    "/dcim/manufacturers/{id}/": {
+    "/api/dcim/manufacturers/{id}/": {
       "get": {
         "operationId": "dcim_manufacturers_read",
         "description": "",
@@ -26194,7 +26194,7 @@
         }
       ]
     },
-    "/dcim/module-bay-templates/": {
+    "/api/dcim/module-bay-templates/": {
       "get": {
         "operationId": "dcim_module-bay-templates_list",
         "description": "",
@@ -26654,7 +26654,7 @@
       },
       "parameters": []
     },
-    "/dcim/module-bay-templates/{id}/": {
+    "/api/dcim/module-bay-templates/{id}/": {
       "get": {
         "operationId": "dcim_module-bay-templates_read",
         "description": "",
@@ -26742,7 +26742,7 @@
         }
       ]
     },
-    "/dcim/module-bays/": {
+    "/api/dcim/module-bays/": {
       "get": {
         "operationId": "dcim_module-bays_list",
         "description": "",
@@ -27652,7 +27652,7 @@
       },
       "parameters": []
     },
-    "/dcim/module-bays/{id}/": {
+    "/api/dcim/module-bays/{id}/": {
       "get": {
         "operationId": "dcim_module-bays_read",
         "description": "",
@@ -27740,7 +27740,7 @@
         }
       ]
     },
-    "/dcim/module-types/": {
+    "/api/dcim/module-types/": {
       "get": {
         "operationId": "dcim_module-types_list",
         "description": "",
@@ -28461,7 +28461,7 @@
       },
       "parameters": []
     },
-    "/dcim/module-types/{id}/": {
+    "/api/dcim/module-types/{id}/": {
       "get": {
         "operationId": "dcim_module-types_read",
         "description": "",
@@ -28549,7 +28549,7 @@
         }
       ]
     },
-    "/dcim/modules/": {
+    "/api/dcim/modules/": {
       "get": {
         "operationId": "dcim_modules_list",
         "description": "",
@@ -29234,7 +29234,7 @@
       },
       "parameters": []
     },
-    "/dcim/modules/{id}/": {
+    "/api/dcim/modules/{id}/": {
       "get": {
         "operationId": "dcim_modules_read",
         "description": "",
@@ -29322,7 +29322,7 @@
         }
       ]
     },
-    "/dcim/platforms/": {
+    "/api/dcim/platforms/": {
       "get": {
         "operationId": "dcim_platforms_list",
         "description": "",
@@ -30034,7 +30034,7 @@
       },
       "parameters": []
     },
-    "/dcim/platforms/{id}/": {
+    "/api/dcim/platforms/{id}/": {
       "get": {
         "operationId": "dcim_platforms_read",
         "description": "",
@@ -30122,7 +30122,7 @@
         }
       ]
     },
-    "/dcim/power-feeds/": {
+    "/api/dcim/power-feeds/": {
       "get": {
         "operationId": "dcim_power-feeds_list",
         "description": "",
@@ -31005,7 +31005,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-feeds/{id}/": {
+    "/api/dcim/power-feeds/{id}/": {
       "get": {
         "operationId": "dcim_power-feeds_read",
         "description": "",
@@ -31093,7 +31093,7 @@
         }
       ]
     },
-    "/dcim/power-feeds/{id}/trace/": {
+    "/api/dcim/power-feeds/{id}/trace/": {
       "get": {
         "operationId": "dcim_power-feeds_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -31125,7 +31125,7 @@
         }
       ]
     },
-    "/dcim/power-outlet-templates/": {
+    "/api/dcim/power-outlet-templates/": {
       "get": {
         "operationId": "dcim_power-outlet-templates_list",
         "description": "",
@@ -31639,7 +31639,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-outlet-templates/{id}/": {
+    "/api/dcim/power-outlet-templates/{id}/": {
       "get": {
         "operationId": "dcim_power-outlet-templates_read",
         "description": "",
@@ -31727,7 +31727,7 @@
         }
       ]
     },
-    "/dcim/power-outlets/": {
+    "/api/dcim/power-outlets/": {
       "get": {
         "operationId": "dcim_power-outlets_list",
         "description": "",
@@ -32736,7 +32736,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-outlets/{id}/": {
+    "/api/dcim/power-outlets/{id}/": {
       "get": {
         "operationId": "dcim_power-outlets_read",
         "description": "",
@@ -32824,7 +32824,7 @@
         }
       ]
     },
-    "/dcim/power-outlets/{id}/trace/": {
+    "/api/dcim/power-outlets/{id}/trace/": {
       "get": {
         "operationId": "dcim_power-outlets_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -32856,7 +32856,7 @@
         }
       ]
     },
-    "/dcim/power-panels/": {
+    "/api/dcim/power-panels/": {
       "get": {
         "operationId": "dcim_power-panels_list",
         "description": "",
@@ -33496,7 +33496,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-panels/{id}/": {
+    "/api/dcim/power-panels/{id}/": {
       "get": {
         "operationId": "dcim_power-panels_read",
         "description": "",
@@ -33584,7 +33584,7 @@
         }
       ]
     },
-    "/dcim/power-port-templates/": {
+    "/api/dcim/power-port-templates/": {
       "get": {
         "operationId": "dcim_power-port-templates_list",
         "description": "",
@@ -34188,7 +34188,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-port-templates/{id}/": {
+    "/api/dcim/power-port-templates/{id}/": {
       "get": {
         "operationId": "dcim_power-port-templates_read",
         "description": "",
@@ -34276,7 +34276,7 @@
         }
       ]
     },
-    "/dcim/power-ports/": {
+    "/api/dcim/power-ports/": {
       "get": {
         "operationId": "dcim_power-ports_list",
         "description": "",
@@ -35375,7 +35375,7 @@
       },
       "parameters": []
     },
-    "/dcim/power-ports/{id}/": {
+    "/api/dcim/power-ports/{id}/": {
       "get": {
         "operationId": "dcim_power-ports_read",
         "description": "",
@@ -35463,7 +35463,7 @@
         }
       ]
     },
-    "/dcim/power-ports/{id}/trace/": {
+    "/api/dcim/power-ports/{id}/trace/": {
       "get": {
         "operationId": "dcim_power-ports_trace",
         "description": "Trace a complete cable path and return each segment as a three-tuple of (termination, cable, termination).",
@@ -35495,7 +35495,7 @@
         }
       ]
     },
-    "/dcim/rack-reservations/": {
+    "/api/dcim/rack-reservations/": {
       "get": {
         "operationId": "dcim_rack-reservations_list",
         "description": "",
@@ -36225,7 +36225,7 @@
       },
       "parameters": []
     },
-    "/dcim/rack-reservations/{id}/": {
+    "/api/dcim/rack-reservations/{id}/": {
       "get": {
         "operationId": "dcim_rack-reservations_read",
         "description": "",
@@ -36313,7 +36313,7 @@
         }
       ]
     },
-    "/dcim/rack-roles/": {
+    "/api/dcim/rack-roles/": {
       "get": {
         "operationId": "dcim_rack-roles_list",
         "description": "",
@@ -37070,7 +37070,7 @@
       },
       "parameters": []
     },
-    "/dcim/rack-roles/{id}/": {
+    "/api/dcim/rack-roles/{id}/": {
       "get": {
         "operationId": "dcim_rack-roles_read",
         "description": "",
@@ -37158,7 +37158,7 @@
         }
       ]
     },
-    "/dcim/racks/": {
+    "/api/dcim/racks/": {
       "get": {
         "operationId": "dcim_racks_list",
         "description": "",
@@ -38644,7 +38644,7 @@
       },
       "parameters": []
     },
-    "/dcim/racks/{id}/": {
+    "/api/dcim/racks/{id}/": {
       "get": {
         "operationId": "dcim_racks_read",
         "description": "",
@@ -38732,7 +38732,7 @@
         }
       ]
     },
-    "/dcim/racks/{id}/elevation/": {
+    "/api/dcim/racks/{id}/elevation/": {
       "get": {
         "operationId": "dcim_racks_elevation",
         "description": "Rack elevation representing the list of rack units. Also supports rendering the elevation as an SVG.",
@@ -38866,7 +38866,7 @@
         }
       ]
     },
-    "/dcim/rear-port-templates/": {
+    "/api/dcim/rear-port-templates/": {
       "get": {
         "operationId": "dcim_rear-port-templates_list",
         "description": "",
@@ -39515,7 +39515,7 @@
       },
       "parameters": []
     },
-    "/dcim/rear-port-templates/{id}/": {
+    "/api/dcim/rear-port-templates/{id}/": {
       "get": {
         "operationId": "dcim_rear-port-templates_read",
         "description": "",
@@ -39603,7 +39603,7 @@
         }
       ]
     },
-    "/dcim/rear-ports/": {
+    "/api/dcim/rear-ports/": {
       "get": {
         "operationId": "dcim_rear-ports_list",
         "description": "",
@@ -40738,7 +40738,7 @@
       },
       "parameters": []
     },
-    "/dcim/rear-ports/{id}/": {
+    "/api/dcim/rear-ports/{id}/": {
       "get": {
         "operationId": "dcim_rear-ports_read",
         "description": "",
@@ -40826,7 +40826,7 @@
         }
       ]
     },
-    "/dcim/rear-ports/{id}/paths/": {
+    "/api/dcim/rear-ports/{id}/paths/": {
       "get": {
         "operationId": "dcim_rear-ports_paths",
         "description": "Return all CablePaths which traverse a given pass-through port.",
@@ -40858,7 +40858,7 @@
         }
       ]
     },
-    "/dcim/regions/": {
+    "/api/dcim/regions/": {
       "get": {
         "operationId": "dcim_regions_list",
         "description": "",
@@ -41606,7 +41606,7 @@
       },
       "parameters": []
     },
-    "/dcim/regions/{id}/": {
+    "/api/dcim/regions/{id}/": {
       "get": {
         "operationId": "dcim_regions_read",
         "description": "",
@@ -41694,7 +41694,7 @@
         }
       ]
     },
-    "/dcim/site-groups/": {
+    "/api/dcim/site-groups/": {
       "get": {
         "operationId": "dcim_site-groups_list",
         "description": "",
@@ -42442,7 +42442,7 @@
       },
       "parameters": []
     },
-    "/dcim/site-groups/{id}/": {
+    "/api/dcim/site-groups/{id}/": {
       "get": {
         "operationId": "dcim_site-groups_read",
         "description": "",
@@ -42530,7 +42530,7 @@
         }
       ]
     },
-    "/dcim/sites/": {
+    "/api/dcim/sites/": {
       "get": {
         "operationId": "dcim_sites_list",
         "description": "",
@@ -43647,7 +43647,7 @@
       },
       "parameters": []
     },
-    "/dcim/sites/{id}/": {
+    "/api/dcim/sites/{id}/": {
       "get": {
         "operationId": "dcim_sites_read",
         "description": "",
@@ -43735,7 +43735,7 @@
         }
       ]
     },
-    "/dcim/virtual-chassis/": {
+    "/api/dcim/virtual-chassis/": {
       "get": {
         "operationId": "dcim_virtual-chassis_list",
         "description": "",
@@ -44474,7 +44474,7 @@
       },
       "parameters": []
     },
-    "/dcim/virtual-chassis/{id}/": {
+    "/api/dcim/virtual-chassis/{id}/": {
       "get": {
         "operationId": "dcim_virtual-chassis_read",
         "description": "",
@@ -44562,7 +44562,7 @@
         }
       ]
     },
-    "/dcim/virtual-device-contexts/": {
+    "/api/dcim/virtual-device-contexts/": {
       "get": {
         "operationId": "dcim_virtual-device-contexts_list",
         "description": "",
@@ -45157,7 +45157,7 @@
       },
       "parameters": []
     },
-    "/dcim/virtual-device-contexts/{id}/": {
+    "/api/dcim/virtual-device-contexts/{id}/": {
       "get": {
         "operationId": "dcim_virtual-device-contexts_read",
         "description": "",
@@ -45245,7 +45245,7 @@
         }
       ]
     },
-    "/extras/config-contexts/": {
+    "/api/extras/config-contexts/": {
       "get": {
         "operationId": "extras_config-contexts_list",
         "description": "",
@@ -46218,7 +46218,7 @@
       },
       "parameters": []
     },
-    "/extras/config-contexts/{id}/": {
+    "/api/extras/config-contexts/{id}/": {
       "get": {
         "operationId": "extras_config-contexts_read",
         "description": "",
@@ -46306,7 +46306,7 @@
         }
       ]
     },
-    "/extras/config-contexts/{id}/sync/": {
+    "/api/extras/config-contexts/{id}/sync/": {
       "post": {
         "operationId": "extras_config-contexts_sync",
         "description": "Provide a /sync API endpoint to synchronize an object's data from its associated DataFile (if any).",
@@ -46341,7 +46341,7 @@
         }
       ]
     },
-    "/extras/config-templates/": {
+    "/api/extras/config-templates/": {
       "get": {
         "operationId": "extras_config-templates_list",
         "description": "",
@@ -46864,7 +46864,7 @@
       },
       "parameters": []
     },
-    "/extras/config-templates/{id}/": {
+    "/api/extras/config-templates/{id}/": {
       "get": {
         "operationId": "extras_config-templates_read",
         "description": "",
@@ -46952,7 +46952,7 @@
         }
       ]
     },
-    "/extras/config-templates/{id}/render/": {
+    "/api/extras/config-templates/{id}/render/": {
       "post": {
         "operationId": "extras_config-templates_render",
         "description": "Render a ConfigTemplate using the context data provided (if any). If the client requests \"text/plain\" data,\nreturn the raw rendered content, rather than serialized JSON.",
@@ -46992,7 +46992,7 @@
         }
       ]
     },
-    "/extras/config-templates/{id}/sync/": {
+    "/api/extras/config-templates/{id}/sync/": {
       "post": {
         "operationId": "extras_config-templates_sync",
         "description": "Provide a /sync API endpoint to synchronize an object's data from its associated DataFile (if any).",
@@ -47027,7 +47027,7 @@
         }
       ]
     },
-    "/extras/content-types/": {
+    "/api/extras/content-types/": {
       "get": {
         "operationId": "extras_content-types_list",
         "description": "Read-only list of ContentTypes. Limit results to ContentTypes pertinent to NetBox objects.",
@@ -47139,7 +47139,7 @@
       },
       "parameters": []
     },
-    "/extras/content-types/{id}/": {
+    "/api/extras/content-types/{id}/": {
       "get": {
         "operationId": "extras_content-types_read",
         "description": "Read-only list of ContentTypes. Limit results to ContentTypes pertinent to NetBox objects.",
@@ -47171,7 +47171,7 @@
         }
       ]
     },
-    "/extras/custom-fields/": {
+    "/api/extras/custom-fields/": {
       "get": {
         "operationId": "extras_custom-fields_list",
         "description": "",
@@ -48009,7 +48009,7 @@
       },
       "parameters": []
     },
-    "/extras/custom-fields/{id}/": {
+    "/api/extras/custom-fields/{id}/": {
       "get": {
         "operationId": "extras_custom-fields_read",
         "description": "",
@@ -48097,7 +48097,7 @@
         }
       ]
     },
-    "/extras/custom-links/": {
+    "/api/extras/custom-links/": {
       "get": {
         "operationId": "extras_custom-links_list",
         "description": "",
@@ -48908,7 +48908,7 @@
       },
       "parameters": []
     },
-    "/extras/custom-links/{id}/": {
+    "/api/extras/custom-links/{id}/": {
       "get": {
         "operationId": "extras_custom-links_read",
         "description": "",
@@ -48996,7 +48996,7 @@
         }
       ]
     },
-    "/extras/dashboard/": {
+    "/api/extras/dashboard/": {
       "get": {
         "operationId": "extras_dashboard_read",
         "description": "",
@@ -49074,7 +49074,7 @@
       },
       "parameters": []
     },
-    "/extras/export-templates/": {
+    "/api/extras/export-templates/": {
       "get": {
         "operationId": "extras_export-templates_list",
         "description": "",
@@ -49723,7 +49723,7 @@
       },
       "parameters": []
     },
-    "/extras/export-templates/{id}/": {
+    "/api/extras/export-templates/{id}/": {
       "get": {
         "operationId": "extras_export-templates_read",
         "description": "",
@@ -49811,7 +49811,7 @@
         }
       ]
     },
-    "/extras/export-templates/{id}/sync/": {
+    "/api/extras/export-templates/{id}/sync/": {
       "post": {
         "operationId": "extras_export-templates_sync",
         "description": "Provide a /sync API endpoint to synchronize an object's data from its associated DataFile (if any).",
@@ -49846,7 +49846,7 @@
         }
       ]
     },
-    "/extras/image-attachments/": {
+    "/api/extras/image-attachments/": {
       "get": {
         "operationId": "extras_image-attachments_list",
         "description": "",
@@ -50261,7 +50261,7 @@
       },
       "parameters": []
     },
-    "/extras/image-attachments/{id}/": {
+    "/api/extras/image-attachments/{id}/": {
       "get": {
         "operationId": "extras_image-attachments_read",
         "description": "",
@@ -50349,7 +50349,7 @@
         }
       ]
     },
-    "/extras/journal-entries/": {
+    "/api/extras/journal-entries/": {
       "get": {
         "operationId": "extras_journal-entries_list",
         "description": "",
@@ -50809,7 +50809,7 @@
       },
       "parameters": []
     },
-    "/extras/journal-entries/{id}/": {
+    "/api/extras/journal-entries/{id}/": {
       "get": {
         "operationId": "extras_journal-entries_read",
         "description": "",
@@ -50897,7 +50897,7 @@
         }
       ]
     },
-    "/extras/object-changes/": {
+    "/api/extras/object-changes/": {
       "get": {
         "operationId": "extras_object-changes_list",
         "description": "Retrieve a list of recent changes.",
@@ -51396,7 +51396,7 @@
       },
       "parameters": []
     },
-    "/extras/object-changes/{id}/": {
+    "/api/extras/object-changes/{id}/": {
       "get": {
         "operationId": "extras_object-changes_read",
         "description": "Retrieve a list of recent changes.",
@@ -51428,7 +51428,7 @@
         }
       ]
     },
-    "/extras/reports/": {
+    "/api/extras/reports/": {
       "get": {
         "operationId": "extras_reports_list",
         "description": "Compile all reports and their related results (if any). Result data is deferred in the list view.",
@@ -51443,7 +51443,7 @@
       },
       "parameters": []
     },
-    "/extras/reports/{id}/": {
+    "/api/extras/reports/{id}/": {
       "get": {
         "operationId": "extras_reports_read",
         "description": "Retrieve a single Report identified as \"<module>.<report>\".",
@@ -51467,7 +51467,7 @@
         }
       ]
     },
-    "/extras/reports/{id}/run/": {
+    "/api/extras/reports/{id}/run/": {
       "post": {
         "operationId": "extras_reports_run",
         "description": "Run a Report identified as \"<module>.<script>\" and return the pending Job as the result",
@@ -51491,7 +51491,7 @@
         }
       ]
     },
-    "/extras/saved-filters/": {
+    "/api/extras/saved-filters/": {
       "get": {
         "operationId": "extras_saved-filters_list",
         "description": "",
@@ -52266,7 +52266,7 @@
       },
       "parameters": []
     },
-    "/extras/saved-filters/{id}/": {
+    "/api/extras/saved-filters/{id}/": {
       "get": {
         "operationId": "extras_saved-filters_read",
         "description": "",
@@ -52354,7 +52354,7 @@
         }
       ]
     },
-    "/extras/scripts/": {
+    "/api/extras/scripts/": {
       "get": {
         "operationId": "extras_scripts_list",
         "description": "",
@@ -52369,7 +52369,7 @@
       },
       "parameters": []
     },
-    "/extras/scripts/{id}/": {
+    "/api/extras/scripts/{id}/": {
       "get": {
         "operationId": "extras_scripts_read",
         "description": "",
@@ -52393,7 +52393,7 @@
         }
       ]
     },
-    "/extras/tags/": {
+    "/api/extras/tags/": {
       "get": {
         "operationId": "extras_tags_list",
         "description": "",
@@ -53150,7 +53150,7 @@
       },
       "parameters": []
     },
-    "/extras/tags/{id}/": {
+    "/api/extras/tags/{id}/": {
       "get": {
         "operationId": "extras_tags_read",
         "description": "",
@@ -53238,7 +53238,7 @@
         }
       ]
     },
-    "/extras/webhooks/": {
+    "/api/extras/webhooks/": {
       "get": {
         "operationId": "extras_webhooks_list",
         "description": "",
@@ -54175,7 +54175,7 @@
       },
       "parameters": []
     },
-    "/extras/webhooks/{id}/": {
+    "/api/extras/webhooks/{id}/": {
       "get": {
         "operationId": "extras_webhooks_read",
         "description": "",
@@ -54263,7 +54263,7 @@
         }
       ]
     },
-    "/ipam/aggregates/": {
+    "/api/ipam/aggregates/": {
       "get": {
         "operationId": "ipam_aggregates_list",
         "description": "",
@@ -54903,7 +54903,7 @@
       },
       "parameters": []
     },
-    "/ipam/aggregates/{id}/": {
+    "/api/ipam/aggregates/{id}/": {
       "get": {
         "operationId": "ipam_aggregates_read",
         "description": "",
@@ -54991,7 +54991,7 @@
         }
       ]
     },
-    "/ipam/asn-ranges/": {
+    "/api/ipam/asn-ranges/": {
       "get": {
         "operationId": "ipam_asn-ranges_list",
         "description": "",
@@ -55766,7 +55766,7 @@
       },
       "parameters": []
     },
-    "/ipam/asn-ranges/{id}/": {
+    "/api/ipam/asn-ranges/{id}/": {
       "get": {
         "operationId": "ipam_asn-ranges_read",
         "description": "",
@@ -55854,7 +55854,7 @@
         }
       ]
     },
-    "/ipam/asn-ranges/{id}/available-asns/": {
+    "/api/ipam/asn-ranges/{id}/available-asns/": {
       "get": {
         "operationId": "ipam_asn-ranges_available-asns_list",
         "description": "",
@@ -55921,7 +55921,7 @@
         }
       ]
     },
-    "/ipam/asns/": {
+    "/api/ipam/asns/": {
       "get": {
         "operationId": "ipam_asns_list",
         "description": "",
@@ -56579,7 +56579,7 @@
       },
       "parameters": []
     },
-    "/ipam/asns/{id}/": {
+    "/api/ipam/asns/{id}/": {
       "get": {
         "operationId": "ipam_asns_read",
         "description": "",
@@ -56667,7 +56667,7 @@
         }
       ]
     },
-    "/ipam/fhrp-group-assignments/": {
+    "/api/ipam/fhrp-group-assignments/": {
       "get": {
         "operationId": "ipam_fhrp-group-assignments_list",
         "description": "",
@@ -57181,7 +57181,7 @@
       },
       "parameters": []
     },
-    "/ipam/fhrp-group-assignments/{id}/": {
+    "/api/ipam/fhrp-group-assignments/{id}/": {
       "get": {
         "operationId": "ipam_fhrp-group-assignments_read",
         "description": "",
@@ -57269,7 +57269,7 @@
         }
       ]
     },
-    "/ipam/fhrp-groups/": {
+    "/api/ipam/fhrp-groups/": {
       "get": {
         "operationId": "ipam_fhrp-groups_list",
         "description": "",
@@ -57927,7 +57927,7 @@
       },
       "parameters": []
     },
-    "/ipam/fhrp-groups/{id}/": {
+    "/api/ipam/fhrp-groups/{id}/": {
       "get": {
         "operationId": "ipam_fhrp-groups_read",
         "description": "",
@@ -58015,7 +58015,7 @@
         }
       ]
     },
-    "/ipam/ip-addresses/": {
+    "/api/ipam/ip-addresses/": {
       "get": {
         "operationId": "ipam_ip-addresses_list",
         "description": "",
@@ -58907,7 +58907,7 @@
       },
       "parameters": []
     },
-    "/ipam/ip-addresses/{id}/": {
+    "/api/ipam/ip-addresses/{id}/": {
       "get": {
         "operationId": "ipam_ip-addresses_read",
         "description": "",
@@ -58995,7 +58995,7 @@
         }
       ]
     },
-    "/ipam/ip-ranges/": {
+    "/api/ipam/ip-ranges/": {
       "get": {
         "operationId": "ipam_ip-ranges_list",
         "description": "",
@@ -59662,7 +59662,7 @@
       },
       "parameters": []
     },
-    "/ipam/ip-ranges/{id}/": {
+    "/api/ipam/ip-ranges/{id}/": {
       "get": {
         "operationId": "ipam_ip-ranges_read",
         "description": "",
@@ -59750,7 +59750,7 @@
         }
       ]
     },
-    "/ipam/ip-ranges/{id}/available-ips/": {
+    "/api/ipam/ip-ranges/{id}/available-ips/": {
       "get": {
         "operationId": "ipam_ip-ranges_available-ips_list",
         "description": "",
@@ -59810,7 +59810,7 @@
         }
       ]
     },
-    "/ipam/l2vpn-terminations/": {
+    "/api/ipam/l2vpn-terminations/": {
       "get": {
         "operationId": "ipam_l2vpn-terminations_list",
         "description": "",
@@ -60513,7 +60513,7 @@
       },
       "parameters": []
     },
-    "/ipam/l2vpn-terminations/{id}/": {
+    "/api/ipam/l2vpn-terminations/{id}/": {
       "get": {
         "operationId": "ipam_l2vpn-terminations_read",
         "description": "",
@@ -60601,7 +60601,7 @@
         }
       ]
     },
-    "/ipam/l2vpns/": {
+    "/api/ipam/l2vpns/": {
       "get": {
         "operationId": "ipam_l2vpns_list",
         "description": "",
@@ -61475,7 +61475,7 @@
       },
       "parameters": []
     },
-    "/ipam/l2vpns/{id}/": {
+    "/api/ipam/l2vpns/{id}/": {
       "get": {
         "operationId": "ipam_l2vpns_read",
         "description": "",
@@ -61563,7 +61563,7 @@
         }
       ]
     },
-    "/ipam/prefixes/": {
+    "/api/ipam/prefixes/": {
       "get": {
         "operationId": "ipam_prefixes_list",
         "description": "",
@@ -62581,7 +62581,7 @@
       },
       "parameters": []
     },
-    "/ipam/prefixes/{id}/": {
+    "/api/ipam/prefixes/{id}/": {
       "get": {
         "operationId": "ipam_prefixes_read",
         "description": "",
@@ -62669,7 +62669,7 @@
         }
       ]
     },
-    "/ipam/prefixes/{id}/available-ips/": {
+    "/api/ipam/prefixes/{id}/available-ips/": {
       "get": {
         "operationId": "ipam_prefixes_available-ips_list",
         "description": "",
@@ -62729,7 +62729,7 @@
         }
       ]
     },
-    "/ipam/prefixes/{id}/available-prefixes/": {
+    "/api/ipam/prefixes/{id}/available-prefixes/": {
       "get": {
         "operationId": "ipam_prefixes_available-prefixes_list",
         "description": "",
@@ -62796,7 +62796,7 @@
         }
       ]
     },
-    "/ipam/rirs/": {
+    "/api/ipam/rirs/": {
       "get": {
         "operationId": "ipam_rirs_list",
         "description": "",
@@ -63463,7 +63463,7 @@
       },
       "parameters": []
     },
-    "/ipam/rirs/{id}/": {
+    "/api/ipam/rirs/{id}/": {
       "get": {
         "operationId": "ipam_rirs_read",
         "description": "",
@@ -63551,7 +63551,7 @@
         }
       ]
     },
-    "/ipam/roles/": {
+    "/api/ipam/roles/": {
       "get": {
         "operationId": "ipam_roles_list",
         "description": "",
@@ -64209,7 +64209,7 @@
       },
       "parameters": []
     },
-    "/ipam/roles/{id}/": {
+    "/api/ipam/roles/{id}/": {
       "get": {
         "operationId": "ipam_roles_read",
         "description": "",
@@ -64297,7 +64297,7 @@
         }
       ]
     },
-    "/ipam/route-targets/": {
+    "/api/ipam/route-targets/": {
       "get": {
         "operationId": "ipam_route-targets_list",
         "description": "",
@@ -65000,7 +65000,7 @@
       },
       "parameters": []
     },
-    "/ipam/route-targets/{id}/": {
+    "/api/ipam/route-targets/{id}/": {
       "get": {
         "operationId": "ipam_route-targets_read",
         "description": "",
@@ -65088,7 +65088,7 @@
         }
       ]
     },
-    "/ipam/service-templates/": {
+    "/api/ipam/service-templates/": {
       "get": {
         "operationId": "ipam_service-templates_list",
         "description": "",
@@ -65575,7 +65575,7 @@
       },
       "parameters": []
     },
-    "/ipam/service-templates/{id}/": {
+    "/api/ipam/service-templates/{id}/": {
       "get": {
         "operationId": "ipam_service-templates_read",
         "description": "",
@@ -65663,7 +65663,7 @@
         }
       ]
     },
-    "/ipam/services/": {
+    "/api/ipam/services/": {
       "get": {
         "operationId": "ipam_services_list",
         "description": "",
@@ -66357,7 +66357,7 @@
       },
       "parameters": []
     },
-    "/ipam/services/{id}/": {
+    "/api/ipam/services/{id}/": {
       "get": {
         "operationId": "ipam_services_read",
         "description": "",
@@ -66445,7 +66445,7 @@
         }
       ]
     },
-    "/ipam/vlan-groups/": {
+    "/api/ipam/vlan-groups/": {
       "get": {
         "operationId": "ipam_vlan-groups_list",
         "description": "",
@@ -67346,7 +67346,7 @@
       },
       "parameters": []
     },
-    "/ipam/vlan-groups/{id}/": {
+    "/api/ipam/vlan-groups/{id}/": {
       "get": {
         "operationId": "ipam_vlan-groups_read",
         "description": "",
@@ -67434,7 +67434,7 @@
         }
       ]
     },
-    "/ipam/vlan-groups/{id}/available-vlans/": {
+    "/api/ipam/vlan-groups/{id}/available-vlans/": {
       "get": {
         "operationId": "ipam_vlan-groups_available-vlans_list",
         "description": "",
@@ -67501,7 +67501,7 @@
         }
       ]
     },
-    "/ipam/vlans/": {
+    "/api/ipam/vlans/": {
       "get": {
         "operationId": "ipam_vlans_list",
         "description": "",
@@ -68438,7 +68438,7 @@
       },
       "parameters": []
     },
-    "/ipam/vlans/{id}/": {
+    "/api/ipam/vlans/{id}/": {
       "get": {
         "operationId": "ipam_vlans_read",
         "description": "",
@@ -68526,7 +68526,7 @@
         }
       ]
     },
-    "/ipam/vrfs/": {
+    "/api/ipam/vrfs/": {
       "get": {
         "operationId": "ipam_vrfs_list",
         "description": "",
@@ -69337,7 +69337,7 @@
       },
       "parameters": []
     },
-    "/ipam/vrfs/{id}/": {
+    "/api/ipam/vrfs/{id}/": {
       "get": {
         "operationId": "ipam_vrfs_read",
         "description": "",
@@ -69425,7 +69425,7 @@
         }
       ]
     },
-    "/status/": {
+    "/api/status/": {
       "get": {
         "operationId": "status_list",
         "description": "A lightweight read-only endpoint for conveying NetBox's current operational status.",
@@ -69440,7 +69440,7 @@
       },
       "parameters": []
     },
-    "/tenancy/contact-assignments/": {
+    "/api/tenancy/contact-assignments/": {
       "get": {
         "operationId": "tenancy_contact-assignments_list",
         "description": "",
@@ -69945,7 +69945,7 @@
       },
       "parameters": []
     },
-    "/tenancy/contact-assignments/{id}/": {
+    "/api/tenancy/contact-assignments/{id}/": {
       "get": {
         "operationId": "tenancy_contact-assignments_read",
         "description": "",
@@ -70033,7 +70033,7 @@
         }
       ]
     },
-    "/tenancy/contact-groups/": {
+    "/api/tenancy/contact-groups/": {
       "get": {
         "operationId": "tenancy_contact-groups_list",
         "description": "",
@@ -70727,7 +70727,7 @@
       },
       "parameters": []
     },
-    "/tenancy/contact-groups/{id}/": {
+    "/api/tenancy/contact-groups/{id}/": {
       "get": {
         "operationId": "tenancy_contact-groups_read",
         "description": "",
@@ -70815,7 +70815,7 @@
         }
       ]
     },
-    "/tenancy/contact-roles/": {
+    "/api/tenancy/contact-roles/": {
       "get": {
         "operationId": "tenancy_contact-roles_list",
         "description": "",
@@ -71473,7 +71473,7 @@
       },
       "parameters": []
     },
-    "/tenancy/contact-roles/{id}/": {
+    "/api/tenancy/contact-roles/{id}/": {
       "get": {
         "operationId": "tenancy_contact-roles_read",
         "description": "",
@@ -71561,7 +71561,7 @@
         }
       ]
     },
-    "/tenancy/contacts/": {
+    "/api/tenancy/contacts/": {
       "get": {
         "operationId": "tenancy_contacts_list",
         "description": "",
@@ -72552,7 +72552,7 @@
       },
       "parameters": []
     },
-    "/tenancy/contacts/{id}/": {
+    "/api/tenancy/contacts/{id}/": {
       "get": {
         "operationId": "tenancy_contacts_read",
         "description": "",
@@ -72640,7 +72640,7 @@
         }
       ]
     },
-    "/tenancy/tenant-groups/": {
+    "/api/tenancy/tenant-groups/": {
       "get": {
         "operationId": "tenancy_tenant-groups_list",
         "description": "",
@@ -73334,7 +73334,7 @@
       },
       "parameters": []
     },
-    "/tenancy/tenant-groups/{id}/": {
+    "/api/tenancy/tenant-groups/{id}/": {
       "get": {
         "operationId": "tenancy_tenant-groups_read",
         "description": "",
@@ -73422,7 +73422,7 @@
         }
       ]
     },
-    "/tenancy/tenants/": {
+    "/api/tenancy/tenants/": {
       "get": {
         "operationId": "tenancy_tenants_list",
         "description": "",
@@ -74170,7 +74170,7 @@
       },
       "parameters": []
     },
-    "/tenancy/tenants/{id}/": {
+    "/api/tenancy/tenants/{id}/": {
       "get": {
         "operationId": "tenancy_tenants_read",
         "description": "",
@@ -74258,7 +74258,7 @@
         }
       ]
     },
-    "/users/config/": {
+    "/api/users/config/": {
       "get": {
         "operationId": "users_config_list",
         "description": "Return the UserConfig for the currently authenticated User.",
@@ -74273,7 +74273,7 @@
       },
       "parameters": []
     },
-    "/users/groups/": {
+    "/api/users/groups/": {
       "get": {
         "operationId": "users_groups_list",
         "description": "",
@@ -74589,7 +74589,7 @@
       },
       "parameters": []
     },
-    "/users/groups/{id}/": {
+    "/api/users/groups/{id}/": {
       "get": {
         "operationId": "users_groups_read",
         "description": "",
@@ -74677,7 +74677,7 @@
         }
       ]
     },
-    "/users/permissions/": {
+    "/api/users/permissions/": {
       "get": {
         "operationId": "users_permissions_list",
         "description": "",
@@ -75191,7 +75191,7 @@
       },
       "parameters": []
     },
-    "/users/permissions/{id}/": {
+    "/api/users/permissions/{id}/": {
       "get": {
         "operationId": "users_permissions_read",
         "description": "",
@@ -75279,7 +75279,7 @@
         }
       ]
     },
-    "/users/tokens/": {
+    "/api/users/tokens/": {
       "get": {
         "operationId": "users_tokens_list",
         "description": "",
@@ -75793,7 +75793,7 @@
       },
       "parameters": []
     },
-    "/users/tokens/provision/": {
+    "/api/users/tokens/provision/": {
       "post": {
         "operationId": "users_tokens_provision_create",
         "description": "Non-authenticated REST API endpoint via which a user may create a Token.",
@@ -75808,7 +75808,7 @@
       },
       "parameters": []
     },
-    "/users/tokens/{id}/": {
+    "/api/users/tokens/{id}/": {
       "get": {
         "operationId": "users_tokens_read",
         "description": "",
@@ -75896,7 +75896,7 @@
         }
       ]
     },
-    "/users/users/": {
+    "/api/users/users/": {
       "get": {
         "operationId": "users_users_list",
         "description": "",
@@ -76563,7 +76563,7 @@
       },
       "parameters": []
     },
-    "/users/users/{id}/": {
+    "/api/users/users/{id}/": {
       "get": {
         "operationId": "users_users_read",
         "description": "",
@@ -76651,7 +76651,7 @@
         }
       ]
     },
-    "/virtualization/cluster-groups/": {
+    "/api/virtualization/cluster-groups/": {
       "get": {
         "operationId": "virtualization_cluster-groups_list",
         "description": "",
@@ -77363,7 +77363,7 @@
       },
       "parameters": []
     },
-    "/virtualization/cluster-groups/{id}/": {
+    "/api/virtualization/cluster-groups/{id}/": {
       "get": {
         "operationId": "virtualization_cluster-groups_read",
         "description": "",
@@ -77451,7 +77451,7 @@
         }
       ]
     },
-    "/virtualization/cluster-types/": {
+    "/api/virtualization/cluster-types/": {
       "get": {
         "operationId": "virtualization_cluster-types_list",
         "description": "",
@@ -78109,7 +78109,7 @@
       },
       "parameters": []
     },
-    "/virtualization/cluster-types/{id}/": {
+    "/api/virtualization/cluster-types/{id}/": {
       "get": {
         "operationId": "virtualization_cluster-types_read",
         "description": "",
@@ -78197,7 +78197,7 @@
         }
       ]
     },
-    "/virtualization/clusters/": {
+    "/api/virtualization/clusters/": {
       "get": {
         "operationId": "virtualization_clusters_list",
         "description": "",
@@ -78981,7 +78981,7 @@
       },
       "parameters": []
     },
-    "/virtualization/clusters/{id}/": {
+    "/api/virtualization/clusters/{id}/": {
       "get": {
         "operationId": "virtualization_clusters_read",
         "description": "",
@@ -79069,7 +79069,7 @@
         }
       ]
     },
-    "/virtualization/interfaces/": {
+    "/api/virtualization/interfaces/": {
       "get": {
         "operationId": "virtualization_interfaces_list",
         "description": "",
@@ -79961,7 +79961,7 @@
       },
       "parameters": []
     },
-    "/virtualization/interfaces/{id}/": {
+    "/api/virtualization/interfaces/{id}/": {
       "get": {
         "operationId": "virtualization_interfaces_read",
         "description": "",
@@ -80049,7 +80049,7 @@
         }
       ]
     },
-    "/virtualization/virtual-machines/": {
+    "/api/virtualization/virtual-machines/": {
       "get": {
         "operationId": "virtualization_virtual-machines_list",
         "description": "",
@@ -81185,7 +81185,7 @@
       },
       "parameters": []
     },
-    "/virtualization/virtual-machines/{id}/": {
+    "/api/virtualization/virtual-machines/{id}/": {
       "get": {
         "operationId": "virtualization_virtual-machines_read",
         "description": "",
@@ -81246,7 +81246,7 @@
         }
       ]
     },
-    "/wireless/wireless-lan-groups/": {
+    "/api/wireless/wireless-lan-groups/": {
       "get": {
         "operationId": "wireless_wireless-lan-groups_list",
         "description": "",
@@ -81940,7 +81940,7 @@
       },
       "parameters": []
     },
-    "/wireless/wireless-lan-groups/{id}/": {
+    "/api/wireless/wireless-lan-groups/{id}/": {
       "get": {
         "operationId": "wireless_wireless-lan-groups_read",
         "description": "",
@@ -82028,7 +82028,7 @@
         }
       ]
     },
-    "/wireless/wireless-lans/": {
+    "/api/wireless/wireless-lans/": {
       "get": {
         "operationId": "wireless_wireless-lans_list",
         "description": "",
@@ -82866,7 +82866,7 @@
       },
       "parameters": []
     },
-    "/wireless/wireless-lans/{id}/": {
+    "/api/wireless/wireless-lans/{id}/": {
       "get": {
         "operationId": "wireless_wireless-lans_read",
         "description": "",
@@ -82954,7 +82954,7 @@
         }
       ]
     },
-    "/wireless/wireless-links/": {
+    "/api/wireless/wireless-links/": {
       "get": {
         "operationId": "wireless_wireless-links_list",
         "description": "",
@@ -83846,7 +83846,7 @@
       },
       "parameters": []
     },
-    "/wireless/wireless-links/{id}/": {
+    "/api/wireless/wireless-links/{id}/": {
       "get": {
         "operationId": "wireless_wireless-links_read",
         "description": "",
@@ -83937,14 +83937,8 @@
   },
   "servers": [
     {
-      "url": "https://{host}/api",
-      "description": "NetBox instance",
-      "variables": {
-        "host": {
-          "default": "netbox.example.com",
-          "description": "Hostname of the NetBox instance"
-        }
-      }
+      "url": "",
+      "description": "NetBox"
     }
   ],
   "components": {

--- a/NetBox/OpenAPIs/netbox-3.7.8.json
+++ b/NetBox/OpenAPIs/netbox-3.7.8.json
@@ -7,7 +7,7 @@
   },
   "security": [
     {
-      "bearerAuth": []
+      "tokenAuth": []
     }
   ],
   "paths": {
@@ -84891,11 +84891,11 @@
       }
     },
     "securitySchemes": {
-      "bearerAuth": {
+      "tokenAuth": {
         "type": "apiKey",
         "in": "header",
         "name": "Authorization",
-        "description": "NetBox API token. Full header value, e.g. `Token <token>` or `Bearer <key>.<token>`."
+        "description": "NetBox API token. Full header value, e.g. `Token <token>`."
       }
     },
     "schemas": {

--- a/NetBox/OpenAPIs/netbox-latest.json
+++ b/NetBox/OpenAPIs/netbox-latest.json
@@ -5,7 +5,7 @@
     "version": "latest",
     "x-vendor-api-version": "4.6.1",
     "x-itential-curated": "Trimmed to 329 of 1194 upstream operations covering common CRUD for network automation: sites/locations/racks, device catalog and devices, interfaces and cabling, IPAM (prefixes/ranges/addresses/VLANs/VRFs), virtualization (clusters/VMs), tenancy, circuits, and tags/custom fields. See the repo README for the full scope and the full spec.",
-    "description": "NetBox is an open-source network source of truth platform for IP address management (IPAM) and data center infrastructure management (DCIM).\n\nAuthentication: API key in Authorization header \u2014 generate a token in NetBox under your user profile \u2192 API Tokens. Pass as Authorization: Token <api_token>.\n\nSource: https://netboxlabs.com/docs/netbox/ | https://github.com/netbox-community/netbox"
+    "description": "NetBox is an open-source network source of truth platform for IP address management (IPAM) and data center infrastructure management (DCIM).\n\nAuthentication: API key in Authorization header \u2014 generate a token in NetBox under your user profile \u2192 API Tokens. Pass as Authorization: Bearer <key>.<token> (v2, current standard); legacy v1 tokens (Authorization: Token <token>) are deprecated as of NetBox v4.6 and will be removed in v5.0.\n\nSource: https://netboxlabs.com/docs/netbox/ | https://github.com/netbox-community/netbox"
   },
   "servers": [
     {
@@ -99888,7 +99888,7 @@
         "type": "apiKey",
         "in": "header",
         "name": "Authorization",
-        "description": "NetBox API token. Full header value, e.g. `Token <token>` or `Bearer <key>.<token>`."
+        "description": "NetBox API token. Full header value: `Bearer <key>.<token>` (v2, current standard) — legacy v1 tokens use `Token <token>` but are deprecated as of NetBox v4.6 and will be removed in v5.0."
       }
     }
   }

--- a/NetBox/OpenAPIs/netbox-latest.json
+++ b/NetBox/OpenAPIs/netbox-latest.json
@@ -9,14 +9,8 @@
   },
   "servers": [
     {
-      "url": "https://{host}/api",
-      "description": "NetBox instance",
-      "variables": {
-        "host": {
-          "default": "netbox.example.com",
-          "description": "Hostname of the NetBox instance"
-        }
-      }
+      "url": "",
+      "description": "NetBox"
     }
   ],
   "security": [


### PR DESCRIPTION
## Summary
- **netbox-3.7.8.json**: security scheme was incorrectly named `bearerAuth` (should be `tokenAuth`, matching NetBox's own OpenAPI schema at every version); also dropped an anachronistic `Bearer`/v2 token mention since v2 tokens didn't exist until NetBox v4.5.
- **netbox-latest.json**: security scheme description now documents `Bearer <key>.<token>` (v2) as the current standard and flags legacy `Token <token>` (v1) as deprecated as of NetBox v4.6, matching NetBox's own current docs.
- **netbox-latest.json**: fixed a bug where `servers[0].url` was `https://{host}/api` while every path already carried an `/api/` prefix, producing a broken doubled `/api/api/...` when resolved.
- **netbox-3.7.8.json**: normalized `servers`/`paths` to the same convention used by NetBox's real `/api/schema/` output (empty server `url`, `/api/` baked into paths) — verified live against `demo.netbox.dev` (v4.6.5).

## Test plan
- [ ] Re-import all three NetBox OpenAPI specs as Integration Models and confirm the resolved base URLs and security scheme resolve correctly
- [ ] Confirm a live request against a NetBox instance using the generated URL succeeds (no doubled `/api/api/`)